### PR TITLE
fix: broken imports in esm + typescript <5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Fixed broken imports in ESM configs using typescript versions lower than 5.5.
+
 ## v0.2.1
 
-- Decrease minimum `typescript-eslint` version to ^8.1.0 (matches import-x plugin).
+- Decreased minimum `typescript-eslint` version to ^8.1.0 (matches import-x plugin).
 
 ## v0.2.0
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,6 +63,8 @@ export default tseslint.config(gitignore(), {
       },
     ],
 
+    'import-x/no-named-as-default-member': 'off',
+
     'n/no-missing-import': 'off',
 
     'eslint-plugin/require-meta-docs-description': [

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0",
     "rxjs": ">=7.0.0",
-    "typescript": ">=4.2.0"
+    "typescript": ">=4.7.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",
@@ -86,7 +86,7 @@
     "rxjs": "^7.0.0",
     "tsup": "^8.3.5",
     "tsx": "^4.19.2",
-    "typescript": "~5.6.3",
+    "typescript": "~5.5.4",
     "typescript-eslint": "^8.13.0",
     "vitest": "^2.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "rxjs": "^7.0.0",
     "tsup": "^8.3.5",
     "tsx": "^4.19.2",
-    "typescript": "~5.5.4",
+    "typescript": "~5.6.3",
     "typescript-eslint": "^8.13.0",
     "vitest": "^2.1.4"
   },

--- a/src/etc/could-be-function.ts
+++ b/src/etc/could-be-function.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import ts from 'typescript';
 import { couldBeType } from './could-be-type';
 
 export function couldBeFunction(type: ts.Type): boolean {

--- a/src/etc/could-be-type.ts
+++ b/src/etc/could-be-type.ts
@@ -1,5 +1,5 @@
 import * as tsutils from 'ts-api-utils';
-import * as ts from 'typescript';
+import ts from 'typescript';
 
 export function couldBeType(
   type: ts.Type,

--- a/src/etc/get-loc.ts
+++ b/src/etc/get-loc.ts
@@ -1,5 +1,5 @@
 import { TSESTree } from '@typescript-eslint/utils';
-import * as ts from 'typescript';
+import ts from 'typescript';
 
 export function getLoc(node: ts.Node): TSESTree.SourceLocation {
   const sourceFile = node.getSourceFile();

--- a/src/etc/get-type-services.ts
+++ b/src/etc/get-type-services.ts
@@ -1,6 +1,6 @@
 import { ESLintUtils, TSESLint, TSESTree } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
-import * as ts from 'typescript';
+import ts from 'typescript';
 import { couldBeFunction } from './could-be-function';
 import { couldBeType as tsutilsEtcCouldBeType } from './could-be-type';
 import { isArrowFunctionExpression, isFunctionDeclaration } from './is';

--- a/src/rules/no-cyclic-action.ts
+++ b/src/rules/no-cyclic-action.ts
@@ -1,6 +1,6 @@
 import { TSESTree as es } from '@typescript-eslint/utils';
 import { stripIndent } from 'common-tags';
-import * as ts from 'typescript';
+import ts from 'typescript';
 import { defaultObservable } from '../constants';
 import { getTypeServices, isCallExpression, isIdentifier } from '../etc';
 import { ruleCreator } from '../utils';

--- a/src/rules/no-unsafe-subject-next.ts
+++ b/src/rules/no-unsafe-subject-next.ts
@@ -1,6 +1,6 @@
 import { TSESTree as es } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
-import * as ts from 'typescript';
+import ts from 'typescript';
 import {
   couldBeType,
   getTypeServices,

--- a/src/rules/throw-error.ts
+++ b/src/rules/throw-error.ts
@@ -1,6 +1,6 @@
 import { TSESTree as es, ESLintUtils } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
-import * as ts from 'typescript';
+import ts from 'typescript';
 import { couldBeFunction, couldBeType, getTypeServices } from '../etc';
 import { ruleCreator } from '../utils';
 

--- a/tests/etc/could-be-type.test.ts
+++ b/tests/etc/could-be-type.test.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import ts from 'typescript';
 import { couldBeType } from '../../src/etc/could-be-type';
 import { createSourceFileAndTypeChecker } from './create-source-file-and-type-checker';
 

--- a/tests/etc/create-source-file-and-type-checker.ts
+++ b/tests/etc/create-source-file-and-type-checker.ts
@@ -1,5 +1,5 @@
 import * as tsvfs from '@typescript/vfs';
-import * as ts from 'typescript';
+import ts from 'typescript';
 
 interface SourceFileAndTypeChecker {
   sourceFile: ts.SourceFile;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,7 +2437,7 @@ __metadata:
     tslib: "npm:^2.1.0"
     tsup: "npm:^8.3.5"
     tsx: "npm:^4.19.2"
-    typescript: "npm:~5.0"
+    typescript: "npm:~5.5.4"
     typescript-eslint: "npm:^8.13.0"
     vitest: "npm:^2.1.4"
   peerDependencies:
@@ -4770,23 +4770,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.0":
-  version: 5.0.4
-  resolution: "typescript@npm:5.0.4"
+"typescript@npm:~5.5.4":
+  version: 5.5.4
+  resolution: "typescript@npm:5.5.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/2f5bd1cead194905957cb34e220b1d6ff1662399adef8ec1864f74620922d860ee35b6e50eafb3b636ea6fd437195e454e1146cb630a4236b5095ed7617395c2
+  checksum: 10c0/422be60f89e661eab29ac488c974b6cc0a660fb2228003b297c3d10c32c90f3bcffc1009b43876a082515a3c376b1eefcce823d6e78982e6878408b9a923199c
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.0#optional!builtin<compat/typescript>":
-  version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#optional!builtin<compat/typescript>::version=5.0.4&hash=b5f058"
+"typescript@patch:typescript@npm%3A~5.5.4#optional!builtin<compat/typescript>":
+  version: 5.5.4
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=379a07"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/c3f7b80577bddf6fab202a7925131ac733bfc414aec298c2404afcddc7a6f242cfa8395cf2d48192265052e11a7577c27f6e5fac8d8fe6a6602023c83d6b3292
+  checksum: 10c0/73409d7b9196a5a1217b3aaad929bf76294d3ce7d6e9766dd880ece296ee91cf7d7db6b16c6c6c630ee5096eccde726c0ef17c7dfa52b01a243e57ae1f09ef07
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,7 +2437,7 @@ __metadata:
     tslib: "npm:^2.1.0"
     tsup: "npm:^8.3.5"
     tsx: "npm:^4.19.2"
-    typescript: "npm:~5.5.4"
+    typescript: "npm:~5.6.3"
     typescript-eslint: "npm:^8.13.0"
     vitest: "npm:^2.1.4"
   peerDependencies:
@@ -4770,23 +4770,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.5.4":
-  version: 5.5.4
-  resolution: "typescript@npm:5.5.4"
+"typescript@npm:~5.6.3":
+  version: 5.6.3
+  resolution: "typescript@npm:5.6.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/422be60f89e661eab29ac488c974b6cc0a660fb2228003b297c3d10c32c90f3bcffc1009b43876a082515a3c376b1eefcce823d6e78982e6878408b9a923199c
+  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.5.4#optional!builtin<compat/typescript>":
-  version: 5.5.4
-  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=379a07"
+"typescript@patch:typescript@npm%3A~5.6.3#optional!builtin<compat/typescript>":
+  version: 5.6.3
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/73409d7b9196a5a1217b3aaad929bf76294d3ce7d6e9766dd880ece296ee91cf7d7db6b16c6c6c630ee5096eccde726c0ef17c7dfa52b01a243e57ae1f09ef07
+  checksum: 10c0/7c9d2e07c81226d60435939618c91ec2ff0b75fbfa106eec3430f0fcf93a584bc6c73176676f532d78c3594fe28a54b36eb40b3d75593071a7ec91301533ace7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,13 +2437,13 @@ __metadata:
     tslib: "npm:^2.1.0"
     tsup: "npm:^8.3.5"
     tsx: "npm:^4.19.2"
-    typescript: "npm:~5.6.3"
+    typescript: "npm:~5.0"
     typescript-eslint: "npm:^8.13.0"
     vitest: "npm:^2.1.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     rxjs: ">=7.0.0"
-    typescript: ">=4.2.0"
+    typescript: ">=4.7.4"
   languageName: unknown
   linkType: soft
 
@@ -4770,23 +4770,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.6.3":
-  version: 5.6.3
-  resolution: "typescript@npm:5.6.3"
+"typescript@npm:~5.0":
+  version: 5.0.4
+  resolution: "typescript@npm:5.0.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
+  checksum: 10c0/2f5bd1cead194905957cb34e220b1d6ff1662399adef8ec1864f74620922d860ee35b6e50eafb3b636ea6fd437195e454e1146cb630a4236b5095ed7617395c2
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.6.3#optional!builtin<compat/typescript>":
-  version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
+"typescript@patch:typescript@npm%3A~5.0#optional!builtin<compat/typescript>":
+  version: 5.0.4
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#optional!builtin<compat/typescript>::version=5.0.4&hash=b5f058"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/7c9d2e07c81226d60435939618c91ec2ff0b75fbfa106eec3430f0fcf93a584bc6c73176676f532d78c3594fe28a54b36eb40b3d75593071a7ec91301533ace7
+  checksum: 10c0/c3f7b80577bddf6fab202a7925131ac733bfc414aec298c2404afcddc7a6f242cfa8395cf2d48192265052e11a7577c27f6e5fac8d8fe6a6602023c83d6b3292
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`import * as ts from "typescript"` does not work as expected in ESM until TypeScript 5.5 (see https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#easier-api-consumption-from-ecmascript-modules).  This was causing projects using an ESM eslint config with TypeScript 4.7 through 5.4 to get:

```
Oops! Something went wrong! :(

ESLint: 8.57.1

TypeError: Cannot read properties of undefined (reading 'Any')
```

This changes to `import ts from "typescript"` so the import works on those older TypeScript versions in ESM.

- Also increase minimum TypeScript version to 4.7.4 to align with `typescript-eslint/typescript-estree`'s supported versions.