### PR TITLE
fix(no-ignored-replay-buffer): check config bufferSize

### DIFF
--- a/docs/rules/no-ignored-replay-buffer.md
+++ b/docs/rules/no-ignored-replay-buffer.md
@@ -15,6 +15,11 @@ import { ReplaySubject } from "rxjs";
 const subject = new ReplaySubject<number>();
 ```
 
+```ts
+import { of, shareReplay } from "rxjs";
+of(42).pipe(shareReplay({ refCount: true }));
+```
+
 Examples of **correct** code for this rule:
 
 ```ts
@@ -25,4 +30,9 @@ const subject = new ReplaySubject<number>(1);
 ```ts
 import { ReplaySubject } from "rxjs";
 const subject = new ReplaySubject<number>(Infinity);
+```
+
+```ts
+import { of, shareReplay } from "rxjs";
+of(42).pipe(shareReplay({ refCount: true, bufferSize: 1 }));
 ```

--- a/tests/rules/no-ignored-replay-buffer.test.ts
+++ b/tests/rules/no-ignored-replay-buffer.test.ts
@@ -26,6 +26,13 @@ ruleTester({ types: false }).run('no-ignored-replay-buffer', noIgnoredReplayBuff
 
       const a = of(42).pipe(shareReplay(1));
     `,
+    fromFixture(
+      stripIndent`
+        // shareReplay with config not ignored
+        import { interval, shareReplay } from "rxjs";
+        interval(1000).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+      `,
+    ),
     stripIndent`
       // namespace ReplaySubject not ignored
       import * as Rx from "rxjs";
@@ -46,6 +53,13 @@ ruleTester({ types: false }).run('no-ignored-replay-buffer', noIgnoredReplayBuff
       import { shareReplay } from "rxjs/operators";
 
       const a = Rx.of(42).pipe(shareReplay(1));
+    `,
+    stripIndent`
+      // namespace shareReplay with config not ignored
+      import * as Rx from "rxjs";
+      import { shareReplay } from "rxjs/operators";
+
+      const a = Rx.of(42).pipe(shareReplay({ bufferSize: 1, refCount: true }));
     `,
     stripIndent`
       // namespace class not ignored
@@ -93,6 +107,15 @@ ruleTester({ types: false }).run('no-ignored-replay-buffer', noIgnoredReplayBuff
     ),
     fromFixture(
       stripIndent`
+        // shareReplay with config ignored
+        import { of, shareReplay } from "rxjs";
+
+        const a = of(42).pipe(shareReplay({ refCount: true }));
+                              ~~~~~~~~~~~ [forbidden]
+      `,
+    ),
+    fromFixture(
+      stripIndent`
         // namespace ReplaySubject ignored
         import * as Rx from "rxjs";
 
@@ -120,6 +143,14 @@ ruleTester({ types: false }).run('no-ignored-replay-buffer', noIgnoredReplayBuff
 
         const a = Rx.of(42).pipe(shareReplay());
                                  ~~~~~~~~~~~ [forbidden]
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // namespace shareReplay with config ignored
+        import * as Rx from "rxjs";
+        const a = Rx.of(42).pipe(Rx.shareReplay({ refCount: true }));
+                                    ~~~~~~~~~~~ [forbidden]
       `,
     ),
     fromFixture(


### PR DESCRIPTION
Fixes https://github.com/cartant/eslint-plugin-rxjs/issues/100

There's also a proposed fix PR in the upstream repo https://github.com/cartant/eslint-plugin-rxjs/pull/114 but I avoided looking at that solution to avoid any license issue, so this solution might be different.

- Fix: if the `shareReplay` operator was passed an object config, then require `bufferSize` to be in that object.
- Fix: the rule wasn't handling if `shareReplay` is imported under a namespace.
  - (Might need to review the entire project.  Since rxjs now recommends importing from "rxjs" instead of "rxjs/operators", there's a risk that many rules also fail to account for that new paradigm.  Note that this rule is the only rule that tests namespace imports for all cases, so we at least should expand that coverage/type of test.)