### PR TITLE
chore: deprecate rxjs-x/macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The package includes the following rules.
 | [ban-operators](docs/rules/ban-operators.md)                           | Disallow banned operators.                                                                           |    |    |    |    |    |
 | [finnish](docs/rules/finnish.md)                                       | Enforce Finnish notation.                                                                            |    |    |    | 💭 |    |
 | [just](docs/rules/just.md)                                             | Require the use of `just` instead of `of`.                                                           |    | 🔧 |    |    |    |
-| [macro](docs/rules/macro.md)                                           | Require the use of the RxJS Tools Babel macro.                                                       |    | 🔧 |    |    |    |
+| [macro](docs/rules/macro.md)                                           | Require the use of the RxJS Tools Babel macro.                                                       |    | 🔧 |    |    | ❌  |
 | [no-async-subscribe](docs/rules/no-async-subscribe.md)                 | Disallow passing `async` functions to `subscribe`.                                                   | ✅  |    |    | 💭 |    |
 | [no-compat](docs/rules/no-compat.md)                                   | Disallow the `rxjs-compat` package.                                                                  |    |    |    |    |    |
 | [no-connectable](docs/rules/no-connectable.md)                         | Disallow operators that return connectable observables.                                              |    |    |    | 💭 |    |

--- a/docs/rules/macro.md
+++ b/docs/rules/macro.md
@@ -1,7 +1,11 @@
 # Require the use of the RxJS Tools Babel macro (`rxjs-x/macro`)
 
+❌ This rule is deprecated.
+
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
 <!-- end auto-generated rule header -->
 
 This rule ensures that modules that import `rxjs` also import the Babel macro for [RxJS Tools](https://rxjs.tools).
+
+This rule is deprecated because [`babel-plugin-rxjs-tools`](https://www.npmjs.com/package/babel-plugin-rxjs-tools) is unmaintained.

--- a/src/rules/macro.ts
+++ b/src/rules/macro.ts
@@ -7,6 +7,7 @@ import { ruleCreator } from '../utils';
 export const macroRule = ruleCreator({
   defaultOptions: [],
   meta: {
+    deprecated: true,
     docs: {
       description: 'Require the use of the RxJS Tools Babel macro.',
     },


### PR DESCRIPTION
The [`babel-plugin-rxjs-tools`](https://www.npmjs.com/package/babel-plugin-rxjs-tools) package is unmaintained (and never left prerelease).  This PR deprecates the lint rule requiring use of that package.

If there are no objections, this rule will be removed before the release of v1.