### PR TITLE
feat(throw-error)!: stop linting throw statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,6 @@ The package includes the following rules.
 | [no-unsafe-takeuntil](docs/rules/no-unsafe-takeuntil.md)               | Disallow applying operators after `takeUntil`.                                                       | ✅  |    |    | 💭 |    |
 | [prefer-observer](docs/rules/prefer-observer.md)                       | Disallow passing separate handlers to `subscribe` and `tap`.                                         |    | 🔧 | 💡 | 💭 |    |
 | [suffix-subjects](docs/rules/suffix-subjects.md)                       | Enforce the use of a suffix in subject identifiers.                                                  |    |    |    | 💭 |    |
-| [throw-error](docs/rules/throw-error.md)                               | Enforce passing only `Error` values to error notifications.                                          |    |    |    | 💭 |    |
+| [throw-error](docs/rules/throw-error.md)                               | Enforce passing only `Error` values to `throwError`.                                                 |    |    |    | 💭 |    |
 
 <!-- end auto-generated rules list -->

--- a/docs/rules/throw-error.md
+++ b/docs/rules/throw-error.md
@@ -1,49 +1,27 @@
-# Enforce passing only `Error` values to error notifications (`rxjs-x/throw-error`)
+# Enforce passing only `Error` values to `throwError` (`rxjs-x/throw-error`)
 
 💭 This rule requires [type information](https://typescript-eslint.io/linting/typed-linting).
 
 <!-- end auto-generated rule header -->
 
-This rule forbids throwing values that are neither `Error` nor `DOMException` instances.
+This rule forbids passing values that are not `Error` objects to `throwError`.
+It's similar to the typescript-eslint [`only-throw-error`](https://typescript-eslint.io/rules/only-throw-error/) rule,
+but is for the `throwError` Observable creation function - not `throw` statements.
 
 ## Rule details
 
 Examples of **incorrect** code for this rule:
 
 ```ts
-throw "Kaboom!";
-```
-
-```ts
 import { throwError } from "rxjs";
-throwError("Kaboom!");
-```
 
-```ts
-import { throwError } from "rxjs";
 throwError(() => "Kaboom!");
 ```
 
 Examples of **correct** code for this rule:
 
 ```ts
-throw new Error("Kaboom!");
-```
-
-```ts
-throw new RangeError("Kaboom!");
-```
-
-```ts
-throw new DOMException("Kaboom!");
-```
-
-```ts
 import { throwError } from "rxjs";
-throwError(new Error("Kaboom!"));
-```
 
-```ts
-import { throwError } from "rxjs";
 throwError(() => new Error("Kaboom!"));
 ```

--- a/docs/rules/throw-error.md
+++ b/docs/rules/throw-error.md
@@ -25,3 +25,14 @@ import { throwError } from "rxjs";
 
 throwError(() => new Error("Kaboom!"));
 ```
+
+## Options
+
+<!-- begin auto-generated rule options list -->
+
+| Name                   | Description                                                 | Type    | Default |
+| :--------------------- | :---------------------------------------------------------- | :------ | :------ |
+| `allowThrowingAny`     | Whether to always allow throwing values typed as `any`.     | Boolean | `true`  |
+| `allowThrowingUnknown` | Whether to always allow throwing values typed as `unknown`. | Boolean | `true`  |
+
+<!-- end auto-generated rule options list -->

--- a/src/rules/throw-error.ts
+++ b/src/rules/throw-error.ts
@@ -40,8 +40,11 @@ export const throwErrorRule = ruleCreator({
 
     function checkThrowArgument(node: es.Node) {
       let type = getTypeAtLocation(node);
+      let reportNode = node;
 
       if (couldBeFunction(type)) {
+        reportNode = (node as es.ArrowFunctionExpression).body ?? node;
+
         const tsNode = esTreeNodeToTSNodeMap.get(node);
         const annotation = (tsNode as ts.ArrowFunction).type;
         const body = (tsNode as ts.ArrowFunction).body;
@@ -62,7 +65,7 @@ export const throwErrorRule = ruleCreator({
 
       context.report({
         messageId: 'forbidden',
-        node,
+        node: reportNode,
       });
     }
 

--- a/src/rules/throw-error.ts
+++ b/src/rules/throw-error.ts
@@ -69,14 +69,21 @@ export const throwErrorRule = ruleCreator({
       });
     }
 
+    function checkNode(node: es.CallExpression) {
+      if (couldBeObservable(node)) {
+        const [arg] = node.arguments;
+        if (arg) {
+          checkThrowArgument(arg);
+        }
+      }
+    }
+
     return {
       'CallExpression[callee.name=\'throwError\']': (node: es.CallExpression) => {
-        if (couldBeObservable(node)) {
-          const [arg] = node.arguments;
-          if (arg) {
-            checkThrowArgument(arg);
-          }
-        }
+        checkNode(node);
+      },
+      'CallExpression[callee.property.name=\'throwError\']': (node: es.CallExpression) => {
+        checkNode(node);
       },
     };
   },

--- a/tests/rules/throw-error.test.ts
+++ b/tests/rules/throw-error.test.ts
@@ -255,5 +255,14 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbidden]
       `,
     ),
+    fromFixture(
+      stripIndent`
+        // namespace import
+        import * as Rx from "rxjs";
+
+        Rx.throwError(() => "Boom!");
+                            ~~~~~~~ [forbidden]
+      `,
+    ),
   ],
 });

--- a/tests/rules/throw-error.test.ts
+++ b/tests/rules/throw-error.test.ts
@@ -33,6 +33,22 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
       const ob1 = throwError(() => new MyFailure("Boom!"));
     `,
     stripIndent`
+      // arrow function return
+      import { throwError } from "rxjs";
+
+      throwError(() => {
+        return new Error("Boom!");
+      });
+    `,
+    stripIndent`
+      // function return
+      import { throwError } from "rxjs";
+
+      throwError(function () {
+        return new Error("Boom!");
+      });
+    `,
+    stripIndent`
       // any
       import { throwError } from "rxjs";
 
@@ -102,6 +118,17 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
         new Error("Not Found"),
         { code: "NOT_FOUND" }
       ));
+    `,
+    stripIndent`
+      // Object.assign arrow function return
+      import { throwError } from "rxjs";
+
+      throwError(() => {
+        return Object.assign(
+          new Error("Not Found"),
+          { code: "NOT_FOUND" }
+        );
+      });
     `,
     stripIndent`
       // no signature
@@ -217,6 +244,15 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
                                      ~~~~ [forbidden]
         const ob4 = throwError(() => undefined);
                                      ~~~~~~~~~ [forbidden]
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // Object.assign with non-Error
+        import { throwError } from "rxjs";
+
+        throwError(() => Object.assign({ message: "Not Found" }, { code: "NOT_FOUND" }));
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbidden]
       `,
     ),
   ],

--- a/tests/rules/throw-error.test.ts
+++ b/tests/rules/throw-error.test.ts
@@ -6,45 +6,32 @@ import { ruleTester } from '../rule-tester';
 ruleTester({ types: true }).run('throw-error', throwErrorRule, {
   valid: [
     stripIndent`
-      // throw Error
-      const a = () => { throw new Error("error"); };
-    `,
-    stripIndent`
-      // throw DOMException
-      const a = () => { throw new DOMException("error"); };
-    `,
-    stripIndent`
-      // throw any
-      const a = () => { throw "error" as any };
-    `,
-    stripIndent`
-      // throw returned any
-      const a = () => { throw errorMessage(); };
-
-      function errorMessage(): any {
-        return "error";
-      }
-    `,
-    stripIndent`
-      // throwError Error
+      // Error
       import { throwError } from "rxjs";
 
       const ob1 = throwError(new Error("Boom!"));
     `,
     stripIndent`
-      // throwError DOMException
+      // RangeError
+      import { throwError } from "rxjs";
+
+      const ob1 = throwError(new RangeError("Boom!"));
+    `,
+    stripIndent`
+      // DOMException
+      /// <reference lib="dom" />
       import { throwError } from "rxjs";
 
       const ob1 = throwError(new DOMException("Boom!"));
     `,
     stripIndent`
-      // throwError any
+      // any
       import { throwError } from "rxjs";
 
       const ob1 = throwError("Boom!" as any);
     `,
     stripIndent`
-      // throwError returned any
+      // returned any
       import { throwError } from "rxjs";
 
       const ob1 = throwError(errorMessage());
@@ -54,13 +41,13 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
       }
     `,
     stripIndent`
-      // throwError unknown
+      // unknown
       import { throwError } from "rxjs";
 
       const ob1 = throwError("Boom!" as unknown);
     `,
     stripIndent`
-      // throwError returned unknown
+      // returned unknown
       import { throwError } from "rxjs";
 
       const ob1 = throwError(errorMessage());
@@ -70,25 +57,26 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
       }
     `,
     stripIndent`
-      // throwError Error with factory
+      // Error with factory
       import { throwError } from "rxjs";
 
       const ob1 = throwError(() => new Error("Boom!"));
     `,
     stripIndent`
-      // throwError DOMException with factory
+      // DOMException with factory
+      /// <reference lib="dom" />
       import { throwError } from "rxjs";
 
       const ob1 = throwError(() => new DOMException("Boom!"));
     `,
     stripIndent`
-      // throwError any with factory
+      // any with factory
       import { throwError } from "rxjs";
 
       const ob1 = throwError(() => "Boom!" as any);
     `,
     stripIndent`
-      // throwError returned any with factory
+      // returned any with factory
       import { throwError } from "rxjs";
 
       const ob1 = throwError(() => errorMessage());
@@ -98,6 +86,16 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
       }
     `,
     stripIndent`
+      // subtype with Object.assign
+      // https://github.com/cartant/rxjs-tslint-rules/issues/86
+      import { throwError } from "rxjs";
+
+      throwError(() => Object.assign(
+        new Error("Not Found"),
+        { code: "NOT_FOUND" }
+      ));
+    `,
+    stripIndent`
       // no signature
       // There will be no signature for callback and
       // that should not effect an internal error.
@@ -105,6 +103,26 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
       callback();
     `,
     stripIndent`
+      // unrelated throw statements (use @typescript-eslint/only-throw-error instead).
+      const a = () => { throw "error"; };
+      const b = () => { throw new Error("error"); };
+
+      const errorMessage = "Boom!";
+      const c = () => { throw errorMessage; };
+
+      const d = () => { throw errorMessage(); };
+      function errorMessage() {
+        return "error";
+      }
+
+      const e = () => { throw new DOMException("error"); };
+      const f = () => { throw "error" as any };
+
+      const g = () => { throw errorMessageAny(); };
+      function errorMessageAny(): any {
+        return "error";
+      }
+
       https://github.com/cartant/rxjs-tslint-rules/issues/85
       try {
         throw new Error("error");
@@ -116,34 +134,7 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
   invalid: [
     fromFixture(
       stripIndent`
-        // throw string
-        const a = () => { throw "error"; };
-                                ~~~~~~~ [forbidden]
-      `,
-    ),
-    fromFixture(
-      stripIndent`
-        // throw returned string
-        const a = () => { throw errorMessage(); };
-                                ~~~~~~~~~~~~~~ [forbidden]
-
-        function errorMessage() {
-          return "error";
-        }
-      `,
-    ),
-    fromFixture(
-      stripIndent`
-        // throw string variable
-        const errorMessage = "Boom!";
-
-        const a = () => { throw errorMessage; };
-                                ~~~~~~~~~~~~ [forbidden]
-      `,
-    ),
-    fromFixture(
-      stripIndent`
-        // throwError string
+        // string
         import { throwError } from "rxjs";
 
         const ob1 = throwError("Boom!");
@@ -152,7 +143,7 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
     ),
     fromFixture(
       stripIndent`
-        // throwError returned string
+        // returned string
         import { throwError } from "rxjs";
 
         const ob1 = throwError(errorMessage());
@@ -165,21 +156,7 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
     ),
     fromFixture(
       stripIndent`
-        https://github.com/cartant/rxjs-tslint-rules/issues/86
-        const a = () => { throw "error"; };
-                                ~~~~~~~ [forbidden]
-        const b = () => { throw new Error("error"); };
-        const c = () => {
-          throw Object.assign(
-            new Error("Not Found"),
-            { code: "NOT_FOUND" }
-          );
-        };
-      `,
-    ),
-    fromFixture(
-      stripIndent`
-        // throwError string with factory
+        // string with factory
         import { throwError } from "rxjs";
 
         const ob1 = throwError(() => "Boom!");
@@ -188,7 +165,7 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
     ),
     fromFixture(
       stripIndent`
-        // throwError returned string with factory
+        // returned string with factory
         import { throwError } from "rxjs";
 
         const ob1 = throwError(() => errorMessage());
@@ -197,6 +174,21 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
         function errorMessage() {
           return "Boom!";
         }
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // falsy
+        import { throwError } from "rxjs";
+
+        const ob1 = throwError(() => 0);
+                               ~~~~~~~ [forbidden]
+        const ob2 = throwError(() => false);
+                               ~~~~~~~~~~~ [forbidden]
+        const ob3 = throwError(() => null);
+                               ~~~~~~~~~~ [forbidden]
+        const ob4 = throwError(() => undefined);
+                               ~~~~~~~~~~~~~~~ [forbidden]
       `,
     ),
   ],

--- a/tests/rules/throw-error.test.ts
+++ b/tests/rules/throw-error.test.ts
@@ -9,74 +9,37 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
       // Error
       import { throwError } from "rxjs";
 
-      const ob1 = throwError(new Error("Boom!"));
+      const ob1 = throwError(() => new Error("Boom!"));
     `,
     stripIndent`
       // RangeError
       import { throwError } from "rxjs";
 
-      const ob1 = throwError(new RangeError("Boom!"));
+      const ob1 = throwError(() => new RangeError("Boom!"));
     `,
     stripIndent`
       // DOMException
       /// <reference lib="dom" />
       import { throwError } from "rxjs";
 
-      const ob1 = throwError(new DOMException("Boom!"));
+      const ob1 = throwError(() => new DOMException("Boom!"));
+    `,
+    stripIndent`
+      // custom Error
+      import { throwError } from "rxjs";
+
+      class MyFailure extends Error {}
+
+      const ob1 = throwError(() => new MyFailure("Boom!"));
     `,
     stripIndent`
       // any
       import { throwError } from "rxjs";
 
-      const ob1 = throwError("Boom!" as any);
-    `,
-    stripIndent`
-      // returned any
-      import { throwError } from "rxjs";
-
-      const ob1 = throwError(errorMessage());
-
-      function errorMessage(): any {
-        return "error";
-      }
-    `,
-    stripIndent`
-      // unknown
-      import { throwError } from "rxjs";
-
-      const ob1 = throwError("Boom!" as unknown);
-    `,
-    stripIndent`
-      // returned unknown
-      import { throwError } from "rxjs";
-
-      const ob1 = throwError(errorMessage());
-
-      function errorMessage(): unknown {
-        return "error";
-      }
-    `,
-    stripIndent`
-      // Error with factory
-      import { throwError } from "rxjs";
-
-      const ob1 = throwError(() => new Error("Boom!"));
-    `,
-    stripIndent`
-      // DOMException with factory
-      /// <reference lib="dom" />
-      import { throwError } from "rxjs";
-
-      const ob1 = throwError(() => new DOMException("Boom!"));
-    `,
-    stripIndent`
-      // any with factory
-      import { throwError } from "rxjs";
-
       const ob1 = throwError(() => "Boom!" as any);
     `,
     stripIndent`
-      // returned any with factory
+      // returned any
       import { throwError } from "rxjs";
 
       const ob1 = throwError(() => errorMessage());
@@ -86,7 +49,52 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
       }
     `,
     stripIndent`
-      // subtype with Object.assign
+      // unknown
+      import { throwError } from "rxjs";
+
+      const ob1 = throwError(() => "Boom!" as unknown);
+    `,
+    stripIndent`
+      // returned unknown
+      import { throwError } from "rxjs";
+
+      const ob1 = throwError(() => errorMessage());
+
+      function errorMessage(): unknown {
+        return "error";
+      }
+    `,
+    stripIndent`
+      // Error without factory (deprecated)
+      import { throwError } from "rxjs";
+
+      const ob1 = throwError(new Error("Boom!"));
+    `,
+    stripIndent`
+      // DOMException without factory (deprecated)
+      /// <reference lib="dom" />
+      import { throwError } from "rxjs";
+
+      const ob1 = throwError(new DOMException("Boom!"));
+    `,
+    stripIndent`
+      // any without factory (deprecated)
+      import { throwError } from "rxjs";
+
+      const ob1 = throwError("Boom!" as any);
+    `,
+    stripIndent`
+      // returned any without factory (deprecated)
+      import { throwError } from "rxjs";
+
+      const ob1 = throwError(errorMessage());
+
+      function errorMessage(): any {
+        return "error";
+      }
+    `,
+    stripIndent`
+      // Object.assign
       // https://github.com/cartant/rxjs-tslint-rules/issues/86
       import { throwError } from "rxjs";
 
@@ -137,13 +145,35 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
         // string
         import { throwError } from "rxjs";
 
+        const ob1 = throwError(() => "Boom!");
+                               ~~~~~~~~~~~~~ [forbidden]
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // returned string
+        import { throwError } from "rxjs";
+
+        const ob1 = throwError(() => errorMessage());
+                               ~~~~~~~~~~~~~~~~~~~~ [forbidden]
+
+        function errorMessage() {
+          return "Boom!";
+        }
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // string without factory (deprecated)
+        import { throwError } from "rxjs";
+
         const ob1 = throwError("Boom!");
                                ~~~~~~~ [forbidden]
       `,
     ),
     fromFixture(
       stripIndent`
-        // returned string
+        // returned string without factory (deprecated)
         import { throwError } from "rxjs";
 
         const ob1 = throwError(errorMessage());
@@ -156,25 +186,23 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
     ),
     fromFixture(
       stripIndent`
-        // string with factory
+        // any not allowed
         import { throwError } from "rxjs";
 
-        const ob1 = throwError(() => "Boom!");
-                               ~~~~~~~~~~~~~ [forbidden]
+        throwError(() => "Boom!" as any);
+                   ~~~~~~~~~~~~~~~~~~~~ [forbidden]
       `,
+      { options: [{ allowThrowingAny: false }] },
     ),
     fromFixture(
       stripIndent`
-        // returned string with factory
+        // unknown not allowed
         import { throwError } from "rxjs";
 
-        const ob1 = throwError(() => errorMessage());
-                               ~~~~~~~~~~~~~~~~~~~~ [forbidden]
-
-        function errorMessage() {
-          return "Boom!";
-        }
+        throwError(() => "Boom!" as unknown);
+                   ~~~~~~~~~~~~~~~~~~~~~~~~ [forbidden]
       `,
+      { options: [{ allowThrowingUnknown: false }] },
     ),
     fromFixture(
       stripIndent`

--- a/tests/rules/throw-error.test.ts
+++ b/tests/rules/throw-error.test.ts
@@ -146,7 +146,7 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
         import { throwError } from "rxjs";
 
         const ob1 = throwError(() => "Boom!");
-                               ~~~~~~~~~~~~~ [forbidden]
+                                     ~~~~~~~ [forbidden]
       `,
     ),
     fromFixture(
@@ -155,7 +155,7 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
         import { throwError } from "rxjs";
 
         const ob1 = throwError(() => errorMessage());
-                               ~~~~~~~~~~~~~~~~~~~~ [forbidden]
+                                     ~~~~~~~~~~~~~~ [forbidden]
 
         function errorMessage() {
           return "Boom!";
@@ -190,7 +190,7 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
         import { throwError } from "rxjs";
 
         throwError(() => "Boom!" as any);
-                   ~~~~~~~~~~~~~~~~~~~~ [forbidden]
+                         ~~~~~~~~~~~~~~ [forbidden]
       `,
       { options: [{ allowThrowingAny: false }] },
     ),
@@ -200,7 +200,7 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
         import { throwError } from "rxjs";
 
         throwError(() => "Boom!" as unknown);
-                   ~~~~~~~~~~~~~~~~~~~~~~~~ [forbidden]
+                         ~~~~~~~~~~~~~~~~~~ [forbidden]
       `,
       { options: [{ allowThrowingUnknown: false }] },
     ),
@@ -210,13 +210,13 @@ ruleTester({ types: true }).run('throw-error', throwErrorRule, {
         import { throwError } from "rxjs";
 
         const ob1 = throwError(() => 0);
-                               ~~~~~~~ [forbidden]
+                                     ~ [forbidden]
         const ob2 = throwError(() => false);
-                               ~~~~~~~~~~~ [forbidden]
+                                     ~~~~~ [forbidden]
         const ob3 = throwError(() => null);
-                               ~~~~~~~~~~ [forbidden]
+                                     ~~~~ [forbidden]
         const ob4 = throwError(() => undefined);
-                               ~~~~~~~~~~~~~~~ [forbidden]
+                                     ~~~~~~~~~ [forbidden]
       `,
     ),
   ],


### PR DESCRIPTION
- Resolves #21 .  Removes functionality that was linting regular js `throw` statements.  Users should prefer https://typescript-eslint.io/rules/only-throw-error/ instead.
- Added options to disallow `any` and `unknown` if users want stricter checking.
- Moved the report node to the return body of the factory instead of the whole function itself.
- Reworked tests to prioritize testing passing a factory function to `throwError` instead of a raw value, because rxjs has deprecated the latter.