### PR TITLE
feat(ban-operators)!: type check, report in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The package includes the following rules.
 | Name                                                                   | Description                                                                                          | 💼 | 🔧 | 💡 | 💭 | ❌  |
 | :--------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- | :- | :- | :- | :- | :- |
 | [ban-observables](docs/rules/ban-observables.md)                       | Disallow banned observable creators.                                                                 |    |    |    |    |    |
-| [ban-operators](docs/rules/ban-operators.md)                           | Disallow banned operators.                                                                           |    |    |    |    |    |
+| [ban-operators](docs/rules/ban-operators.md)                           | Disallow banned operators.                                                                           |    |    |    | 💭 |    |
 | [finnish](docs/rules/finnish.md)                                       | Enforce Finnish notation.                                                                            |    |    |    | 💭 |    |
 | [just](docs/rules/just.md)                                             | Require the use of `just` instead of `of`.                                                           |    | 🔧 |    |    |    |
 | [macro](docs/rules/macro.md)                                           | Require the use of the RxJS Tools Babel macro.                                                       |    | 🔧 |    |    | ❌  |

--- a/docs/rules/ban-operators.md
+++ b/docs/rules/ban-operators.md
@@ -1,5 +1,7 @@
 # Disallow banned operators (`rxjs-x/ban-operators`)
 
+💭 This rule requires [type information](https://typescript-eslint.io/linting/typed-linting).
+
 <!-- end auto-generated rule header -->
 
 This rule can be configured so that developers can ban any operators they want to avoid in their project.

--- a/src/rules/ban-operators.ts
+++ b/src/rules/ban-operators.ts
@@ -59,10 +59,10 @@ export const banOperatorsRule = ruleCreator({
     }
 
     return {
-      'CallExpression[callee.name]': (node: es.CallExpression) => {
+      'CallExpression[callee.property.name=\'pipe\'] > CallExpression[callee.name]': (node: es.CallExpression) => {
         checkNode(node.callee);
       },
-      'CallExpression[callee.type="MemberExpression"]': (node: es.CallExpression) => {
+      'CallExpression[callee.property.name=\'pipe\'] > CallExpression[callee.type="MemberExpression"]': (node: es.CallExpression) => {
         const callee = node.callee as es.MemberExpression;
         checkNode(callee.property);
       },

--- a/tests/rules/ban-operators.test.ts
+++ b/tests/rules/ban-operators.test.ts
@@ -3,34 +3,112 @@ import { banOperatorsRule } from '../../src/rules/ban-operators';
 import { fromFixture } from '../etc';
 import { ruleTester } from '../rule-tester';
 
-ruleTester({ types: false }).run('ban-operators', banOperatorsRule, {
+ruleTester({ types: true }).run('ban-operators', banOperatorsRule, {
   valid: [
     {
-      code: `import { concat, merge as m, mergeMap as mm } from "rxjs/operators";`,
+      code: stripIndent`
+        // root import
+        import { of, concat, merge as m, mergeMap as mm } from "rxjs";
+
+        of('a').pipe(concat(of('b')));
+        of(1).pipe(m(of(2)));
+        of('a').pipe(mm(x => of(x + '1')));
+      `,
+      options: [{}],
     },
     {
-      code: `import { concat, merge as m, mergeMap as mm } from "rxjs";`,
+      code: stripIndent`
+        // namespace import
+        import * as Rx from "rxjs";
+
+        Rx.of('a').pipe(Rx.concat(Rx.of('b')));
+        Rx.of(1).pipe(Rx.merge(Rx.of(2)));
+        Rx.of('a').pipe(Rx.mergeMap(x => Rx.of(x + '1')));
+      `,
+      options: [{}],
     },
     {
-      // This won't effect errors, because only imports from "rxjs/operators"
-      // are checked. To support banning operators from "rxjs", it'll need to
-      // check types.
-      code: `import { concat, merge as m, mergeMap as mm } from "rxjs";`,
-      options: [
-        {
-          concat: true,
-          merge: 'because I say so',
-          mergeMap: false,
-        },
-      ],
+      code: stripIndent`
+        // operators path import (deprecated)
+        import { of, concat, merge as m, mergeMap as mm } from "rxjs/operators";
+
+        of('a').pipe(concat(of('b')));
+        of(1).pipe(m(of(2)));
+        of('a').pipe(mm(x => of(x + '1')));
+      `,
+      options: [{}],
+    },
+    stripIndent`
+      // no options
+      import { of, concat } from "rxjs";
+
+      of('a').pipe(concat(of('b')));
+    `,
+    {
+      code: stripIndent`
+        // non-RxJS operator
+        import { of } from "rxjs";
+
+        function concat() {}
+
+        of('a').pipe(concat());
+      `,
+      options: [{ concat: true }],
     },
   ],
   invalid: [
     fromFixture(
       stripIndent`
-        import { concat, merge as m, mergeMap as mm } from "rxjs/operators";
-                 ~~~~~~ [forbidden { "name": "concat", "explanation": "" }]
-                         ~~~~~ [forbidden { "name": "merge", "explanation": ": because I say so" }]
+        // root import
+        import { of, concat, merge as m, mergeMap as mm } from "rxjs";
+
+        of('a').pipe(concat(of('b')));
+                     ~~~~~~ [forbidden { "name": "concat", "explanation": "" }]
+        of(1).pipe(m(of(2)));
+                   ~ [forbidden { "name": "merge", "explanation": ": because I say so" }]
+        of('a').pipe(mm(x => of(x + '1')));
+      `,
+      {
+        options: [
+          {
+            concat: true,
+            merge: 'because I say so',
+            mergeMap: false,
+          },
+        ],
+      },
+    ),
+    fromFixture(
+      stripIndent`
+        // namespace import
+        import * as Rx from "rxjs";
+
+        Rx.of('a').pipe(Rx.concat(Rx.of('b')));
+                           ~~~~~~ [forbidden { "name": "concat", "explanation": "" }]
+        Rx.of(1).pipe(Rx.merge(Rx.of(2)));
+                         ~~~~~ [forbidden { "name": "merge", "explanation": "" }]
+        Rx.of('a').pipe(Rx.mergeMap(x => Rx.of(x + '1')));
+      `,
+      {
+        options: [
+          {
+            concat: true,
+            merge: true,
+            mergeMap: false,
+          },
+        ],
+      },
+    ),
+    fromFixture(
+      stripIndent`
+        // operators path import (deprecated)
+        import { of, concat, merge as m, mergeMap as mm } from "rxjs/operators";
+
+        of('a').pipe(concat(of('b')));
+                     ~~~~~~ [forbidden { "name": "concat", "explanation": "" }]
+        of(1).pipe(m(of(2)));
+                   ~ [forbidden { "name": "merge", "explanation": ": because I say so" }]
+        of('a').pipe(mm(x => of(x + '1')));
       `,
       {
         options: [

--- a/tests/rules/ban-operators.test.ts
+++ b/tests/rules/ban-operators.test.ts
@@ -55,6 +55,16 @@ ruleTester({ types: true }).run('ban-operators', banOperatorsRule, {
       `,
       options: [{ concat: true }],
     },
+    {
+      code: stripIndent`
+        // only within pipe
+        import { of, concat } from "rxjs";
+
+        // For performance reasons, we don't lint operators used outside of pipe.
+        concat(of('a'));
+      `,
+      options: [{ concat: true }],
+    },
   ],
   invalid: [
     fromFixture(


### PR DESCRIPTION
BREAKING CHANGE: this rule now requires typed linting.

- Resolves #7 .  Reworked `ban-operators` to support banning operators imported from root "rxjs" too.
  - This uses typed linting to actually check the operator's type instead of just reading the import statement.  This was done based on the original maintainer's comments in the unit tests indicating this was necessary.
- Also resolves upstream https://github.com/cartant/eslint-plugin-rxjs/issues/96 .  Banned operators are now reported at the area they're used in the code instead of the import statement.
  - This allows developers to `eslint-disable-next-line` to allow banned operators more precisely.
- This also resolves the only blocker before #8 can be worked.
- NOTE: this only runs inside of `pipe()` due to performance reasons.
- If users still want to completely ban an operator via its import, they can use the built-in ESLint rule `no-restricted-imports` (or the typescript-eslint equivalent `@typescript-eslint/no-restircted-imports`) with the `importNames` names option.
  - Technically users could also use `ban-observables`, since that rule doesn't distinguish between operators and static creation function exported from "rxjs"...