### PR TITLE
docs(no-async-subscribe): additional explanation

### DIFF
--- a/docs/rules/no-async-subscribe.md
+++ b/docs/rules/no-async-subscribe.md
@@ -7,6 +7,9 @@
 <!-- end auto-generated rule header -->
 
 This rule effects failures if async functions are passed to `subscribe`.
+Developers are encouraged to avoid race conditions
+by instead using RxJS operators which can handle both Promises and Observables
+(e.g. `concatMap`, `switchMap`, `mergeMap`, `exhaustMap`).
 
 ## Rule details
 
@@ -14,16 +17,26 @@ Examples of **incorrect** code for this rule:
 
 ```ts
 import { of } from "rxjs";
-of(42).subscribe(async () => console.log(value));
+
+of(42).subscribe(async value => {
+    const data1 = await fetch(`https://api.some.com/things/${value}`);
+    const data2 = await fetch(`https://api.some.com/things/${data1.id}`);
+    console.log(data2);
+});
 ```
 
 Examples of **correct** code for this rule:
 
 ```ts
 import { of } from "rxjs";
-of(42).subscribe(() => console.log(value));
+
+of(42).pipe(
+    switchMap(value => fetch(`http://api.some.com/things/${value}`)),
+    switchMap(data1 => fetch(`http://api.some.com/things/${data1.id}`)),
+).subscribe(data2 => console.log(data2));
 ```
 
 ## Further reading
 
 - [Why does this rule exist?](https://stackoverflow.com/q/71559135)
+- [Higher-order Observables](https://rxjs.dev/guide/higher-order-observables)


### PR DESCRIPTION
I frequently see `no-async-subscribe` triggered by developers new to RxJS trying to use Promises.  Additional explanation of this rule is necessary.