### PR TITLE
fix(no-ignored-error): check observer object too

### DIFF
--- a/src/rules/no-ignored-error.ts
+++ b/src/rules/no-ignored-error.ts
@@ -1,5 +1,5 @@
-import { TSESTree as es } from '@typescript-eslint/utils';
-import { getTypeServices } from '../etc';
+import { TSESTree as es, ESLintUtils } from '@typescript-eslint/utils';
+import { getTypeServices, isIdentifier, isMemberExpression, isObjectExpression, isProperty } from '../etc';
 import { ruleCreator } from '../utils';
 
 export const noIgnoredErrorRule = ruleCreator({
@@ -18,7 +18,48 @@ export const noIgnoredErrorRule = ruleCreator({
   },
   name: 'no-ignored-error',
   create: (context) => {
+    const { getTypeAtLocation } = ESLintUtils.getParserServices(context);
     const { couldBeObservable, couldBeFunction } = getTypeServices(context);
+
+    function isMissingErrorCallback(callExpression: es.CallExpression): boolean {
+      if (callExpression.arguments.length >= 2) {
+        return false;
+      }
+      return couldBeFunction(callExpression.arguments[0]);
+    }
+
+    function isObjMissingError(arg: es.ObjectExpression): boolean {
+      return !arg.properties.some(
+        property =>
+          isProperty(property)
+          && isIdentifier(property.key)
+          && property.key.name === 'error',
+      );
+    }
+
+    function isTypeMissingError(arg: es.Identifier): boolean {
+      const argType = getTypeAtLocation(arg);
+      return !argType?.getProperties().some(p => p.name === 'error');
+    }
+
+    function isMissingErrorProperty(callExpression: es.CallExpression): boolean {
+      if (callExpression.arguments.length !== 1) {
+        return false;
+      }
+
+      const [arg] = callExpression.arguments;
+
+      if (isObjectExpression(arg)) {
+        return isObjMissingError(arg);
+      }
+      if (isIdentifier(arg)) {
+        return isTypeMissingError(arg);
+      }
+      if (isMemberExpression(arg) && isIdentifier(arg.property)) {
+        return isTypeMissingError(arg.property);
+      }
+      return false;
+    }
 
     return {
       'CallExpression[arguments.length > 0] > MemberExpression > Identifier[name=\'subscribe\']':
@@ -27,9 +68,9 @@ export const noIgnoredErrorRule = ruleCreator({
           const callExpression = memberExpression.parent as es.CallExpression;
 
           if (
-            callExpression.arguments.length < 2
+            (isMissingErrorCallback(callExpression)
+              || isMissingErrorProperty(callExpression))
             && couldBeObservable(memberExpression.object)
-            && couldBeFunction(callExpression.arguments[0])
           ) {
             context.report({
               messageId: 'forbidden',

--- a/tests/rules/no-ignored-error.test.ts
+++ b/tests/rules/no-ignored-error.test.ts
@@ -12,6 +12,19 @@ ruleTester({ types: true }).run('no-ignored-error', noIgnoredErrorRule, {
       observable.subscribe(() => {}, () => {});
     `,
     stripIndent`
+      // observer argument
+      import { of } from "rxjs";
+
+      const observable = of([1, 2]);
+      observable.subscribe({ next: () => {}, error: () => {} });
+
+      const observer1 = { next: () => {}, error: () => {} };
+      observable.subscribe(observer1);
+
+      const obj = { observer: observer1 };
+      observable.subscribe(obj.observer);
+    `,
+    stripIndent`
       // subject
       import { Subject } from "rxjs";
       const subject = new Subject<any>();
@@ -83,6 +96,22 @@ ruleTester({ types: true }).run('no-ignored-error', noIgnoredErrorRule, {
           return obs.subscribe((v: T) => {})
                      ~~~~~~~~~ [forbidden]
         }
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // observer argument
+        import { of } from "rxjs";
+
+        const observable = of([1, 2]);
+        observable.subscribe({ next: () => {} });
+                   ~~~~~~~~~ [forbidden]
+        const observer1 = { next: () => {} };
+        observable.subscribe(observer1);
+                   ~~~~~~~~~ [forbidden]
+        const obj = { observer: observer1 };
+        observable.subscribe(obj.observer1);
+                   ~~~~~~~~~ [forbidden]
       `,
     ),
   ],


### PR DESCRIPTION
Fixes lack of error when passing an observer object into `subscribe` that's lacking an `error` property.  Previously this rule would only fire if passing in separate callbacks.

Resolves upstream https://github.com/cartant/eslint-plugin-rxjs/issues/94