### PR TITLE
feat(no-implicit-any-catch)!: default to allow explicit any

### DIFF
--- a/docs/rules/no-implicit-any-catch.md
+++ b/docs/rules/no-implicit-any-catch.md
@@ -74,11 +74,11 @@ throwError(() => new Error("Kaboom!")).pipe(
 
 | Name               | Description                                           | Type    | Default |
 | :----------------- | :---------------------------------------------------- | :------ | :------ |
-| `allowExplicitAny` | Allow error variable to be explicitly typed as `any`. | Boolean | `false` |
+| `allowExplicitAny` | Allow error variable to be explicitly typed as `any`. | Boolean | `true`  |
 
 <!-- end auto-generated rule options list -->
 
-This rule accepts a single option which is an object with an `allowExplicitAny` property that determines whether or not the error variable can be explicitly typed as `any`. By default, the use of explicit `any` is forbidden.
+This rule accepts a single option which is an object with an `allowExplicitAny` property that determines whether or not the error variable can be explicitly typed as `any`. By default, the use of explicit `any` is allowed.
 
 ```json
 {

--- a/src/rules/no-implicit-any-catch.ts
+++ b/src/rules/no-implicit-any-catch.ts
@@ -59,7 +59,7 @@ export const noImplicitAnyCatchRule = ruleCreator({
           allowExplicitAny: {
             type: 'boolean',
             description: 'Allow error variable to be explicitly typed as `any`.',
-            default: false,
+            default: true,
           },
         },
         type: 'object',
@@ -70,7 +70,7 @@ export const noImplicitAnyCatchRule = ruleCreator({
   name: 'no-implicit-any-catch',
   create: (context) => {
     const [config = {}] = context.options;
-    const { allowExplicitAny = false } = config;
+    const { allowExplicitAny = true } = config;
     const { couldBeObservable } = getTypeServices(context);
     const sourceCode = context.sourceCode;
 

--- a/tests/rules/no-implicit-any-catch.test.ts
+++ b/tests/rules/no-implicit-any-catch.test.ts
@@ -59,7 +59,7 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
           catchError((error: unknown) => console.error(error))
         );
       `,
-      options: [{ allowExplicitAny: false }],
+      options: [{ allowExplicitAny: true }],
     },
     {
       code: stripIndent`
@@ -71,7 +71,7 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
           catchError(function (error: unknown) { console.error(error); })
         );
       `,
-      options: [{ allowExplicitAny: false }],
+      options: [{ allowExplicitAny: true }],
     },
     {
       code: stripIndent`
@@ -83,7 +83,6 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
           catchError((error: any) => console.error(error))
         );
       `,
-      options: [{ allowExplicitAny: true }],
     },
     {
       code: stripIndent`
@@ -95,7 +94,6 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
           catchError(function (error: any) { console.error(error); })
         );
       `,
-      options: [{ allowExplicitAny: true }],
     },
     {
       code: stripIndent`
@@ -110,7 +108,7 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
     },
     {
       code: stripIndent`
-        // subscribe; arrow; explicit any
+        // subscribe; arrow; explicit any; default option
         import { throwError } from "rxjs";
 
         throwError("Kaboom!").subscribe(
@@ -118,7 +116,6 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
           (error: any) => console.error(error)
         );
       `,
-      options: [{ allowExplicitAny: true }],
     },
     {
       code: stripIndent`
@@ -132,14 +129,13 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
     },
     {
       code: stripIndent`
-        // subscribe observer; arrow; explicit any
+        // subscribe observer; arrow; explicit any; default option
         import { throwError } from "rxjs";
 
         throwError("Kaboom!").subscribe({
           error: (error: any) => console.error(error)
         });
       `,
-      options: [{ allowExplicitAny: true }],
     },
     {
       code: stripIndent`
@@ -155,7 +151,7 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
     },
     {
       code: stripIndent`
-        // tap; arrow; explicit any
+        // tap; arrow; explicit any; default option
         import { throwError } from "rxjs";
         import { tap } from "rxjs/operators";
 
@@ -164,7 +160,6 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
           (error: any) => console.error(error)
         ));
       `,
-      options: [{ allowExplicitAny: true }],
     },
     {
       code: stripIndent`
@@ -179,7 +174,7 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
     },
     {
       code: stripIndent`
-        // tap observer; arrow; explicit any
+        // tap observer; arrow; explicit any; default option
         import { throwError } from "rxjs";
         import { tap } from "rxjs/operators";
 
@@ -187,7 +182,6 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
           error: (error: any) => console.error(error)
         }));
       `,
-      options: [{ allowExplicitAny: true }],
     },
     {
       code: stripIndent`
@@ -304,80 +298,6 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
             messageId: 'suggestExplicitUnknown',
             output: stripIndent`
               // non-arrow; implicit any
-              import { throwError } from "rxjs";
-              import { catchError } from "rxjs/operators";
-
-              throwError("Kaboom!").pipe(
-                catchError(function (error: unknown) { console.error(error); })
-              );
-            `,
-          },
-        ],
-      },
-    ),
-    fromFixture(
-      stripIndent`
-        // arrow; explicit any; default option
-        import { throwError } from "rxjs";
-        import { catchError } from "rxjs/operators";
-
-        throwError("Kaboom!").pipe(
-          catchError((error: any) => console.error(error))
-                      ~~~~~~~~~~ [explicitAny suggest]
-        );
-      `,
-      {
-        output: stripIndent`
-          // arrow; explicit any; default option
-          import { throwError } from "rxjs";
-          import { catchError } from "rxjs/operators";
-
-          throwError("Kaboom!").pipe(
-            catchError((error: unknown) => console.error(error))
-          );
-        `,
-        suggestions: [
-          {
-            messageId: 'suggestExplicitUnknown',
-            output: stripIndent`
-              // arrow; explicit any; default option
-              import { throwError } from "rxjs";
-              import { catchError } from "rxjs/operators";
-
-              throwError("Kaboom!").pipe(
-                catchError((error: unknown) => console.error(error))
-              );
-            `,
-          },
-        ],
-      },
-    ),
-    fromFixture(
-      stripIndent`
-        // non-arrow; explicit any; default option
-        import { throwError } from "rxjs";
-        import { catchError } from "rxjs/operators";
-
-        throwError("Kaboom!").pipe(
-          catchError(function (error: any) { console.error(error); })
-                               ~~~~~~~~~~ [explicitAny suggest]
-        );
-      `,
-      {
-        output: stripIndent`
-          // non-arrow; explicit any; default option
-          import { throwError } from "rxjs";
-          import { catchError } from "rxjs/operators";
-
-          throwError("Kaboom!").pipe(
-            catchError(function (error: unknown) { console.error(error); })
-          );
-        `,
-        suggestions: [
-          {
-            messageId: 'suggestExplicitUnknown',
-            output: stripIndent`
-              // non-arrow; explicit any; default option
               import { throwError } from "rxjs";
               import { catchError } from "rxjs/operators";
 
@@ -597,43 +517,6 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
     ),
     fromFixture(
       stripIndent`
-        // subscribe; arrow; explicit any; default option
-        import { throwError } from "rxjs";
-
-        throwError("Kaboom!").subscribe(
-          undefined,
-          (error: any) => console.error(error)
-           ~~~~~~~~~~ [explicitAny suggest]
-        );
-      `,
-      {
-        output: stripIndent`
-          // subscribe; arrow; explicit any; default option
-          import { throwError } from "rxjs";
-
-          throwError("Kaboom!").subscribe(
-            undefined,
-            (error: unknown) => console.error(error)
-          );
-        `,
-        suggestions: [
-          {
-            messageId: 'suggestExplicitUnknown',
-            output: stripIndent`
-              // subscribe; arrow; explicit any; default option
-              import { throwError } from "rxjs";
-
-              throwError("Kaboom!").subscribe(
-                undefined,
-                (error: unknown) => console.error(error)
-              );
-            `,
-          },
-        ],
-      },
-    ),
-    fromFixture(
-      stripIndent`
         // subscribe; arrow; explicit any; explicit option
         import { throwError } from "rxjs";
 
@@ -756,40 +639,6 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
             messageId: 'suggestExplicitUnknown',
             output: stripIndent`
               // subscribe observer; arrow; no parentheses; implicit any
-              import { throwError } from "rxjs";
-
-              throwError("Kaboom!").subscribe({
-                error: (error: unknown) => console.error(error)
-              });
-            `,
-          },
-        ],
-      },
-    ),
-    fromFixture(
-      stripIndent`
-        // subscribe observer; arrow; explicit any; default option
-        import { throwError } from "rxjs";
-
-        throwError("Kaboom!").subscribe({
-          error: (error: any) => console.error(error)
-                  ~~~~~~~~~~ [explicitAny suggest]
-        });
-      `,
-      {
-        output: stripIndent`
-          // subscribe observer; arrow; explicit any; default option
-          import { throwError } from "rxjs";
-
-          throwError("Kaboom!").subscribe({
-            error: (error: unknown) => console.error(error)
-          });
-        `,
-        suggestions: [
-          {
-            messageId: 'suggestExplicitUnknown',
-            output: stripIndent`
-              // subscribe observer; arrow; explicit any; default option
               import { throwError } from "rxjs";
 
               throwError("Kaboom!").subscribe({
@@ -943,46 +792,6 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
     ),
     fromFixture(
       stripIndent`
-        // tap; arrow; explicit any; default option
-        import { throwError } from "rxjs";
-        import { tap } from "rxjs/operators";
-
-        throwError("Kaboom!").pipe(tap(
-          undefined,
-          (error: any) => console.error(error)
-           ~~~~~~~~~~ [explicitAny suggest]
-        ));
-      `,
-      {
-        output: stripIndent`
-          // tap; arrow; explicit any; default option
-          import { throwError } from "rxjs";
-          import { tap } from "rxjs/operators";
-
-          throwError("Kaboom!").pipe(tap(
-            undefined,
-            (error: unknown) => console.error(error)
-          ));
-        `,
-        suggestions: [
-          {
-            messageId: 'suggestExplicitUnknown',
-            output: stripIndent`
-              // tap; arrow; explicit any; default option
-              import { throwError } from "rxjs";
-              import { tap } from "rxjs/operators";
-
-              throwError("Kaboom!").pipe(tap(
-                undefined,
-                (error: unknown) => console.error(error)
-              ));
-            `,
-          },
-        ],
-      },
-    ),
-    fromFixture(
-      stripIndent`
         // tap; arrow; explicit any; explicit option
         import { throwError } from "rxjs";
         import { tap } from "rxjs/operators";
@@ -1115,43 +924,6 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
             messageId: 'suggestExplicitUnknown',
             output: stripIndent`
               // tap observer; arrow; no parentheses; implicit any
-              import { throwError } from "rxjs";
-              import { tap } from "rxjs/operators";
-
-              throwError("Kaboom!").pipe(tap({
-                error: (error: unknown) => console.error(error)
-              }));
-            `,
-          },
-        ],
-      },
-    ),
-    fromFixture(
-      stripIndent`
-        // tap observer; arrow; explicit any; default option
-        import { throwError } from "rxjs";
-        import { tap } from "rxjs/operators";
-
-        throwError("Kaboom!").pipe(tap({
-          error: (error: any) => console.error(error)
-                  ~~~~~~~~~~ [explicitAny suggest]
-        }));
-      `,
-      {
-        output: stripIndent`
-          // tap observer; arrow; explicit any; default option
-          import { throwError } from "rxjs";
-          import { tap } from "rxjs/operators";
-
-          throwError("Kaboom!").pipe(tap({
-            error: (error: unknown) => console.error(error)
-          }));
-        `,
-        suggestions: [
-          {
-            messageId: 'suggestExplicitUnknown',
-            output: stripIndent`
-              // tap observer; arrow; explicit any; default option
               import { throwError } from "rxjs";
               import { tap } from "rxjs/operators";
 


### PR DESCRIPTION
BREAKING CHANGE: allowExplicitAny now defaults to `true` instead of `false`.

This change was made for several reasons:

1. To align with other rules in this codebase dealing with explicit `any` (namely `throw-error`, which allows `any` by default).
2. To align with the rule's name: to a casual reader, this rule seems to only ban implicit `any`, not explicit too.
3. Lax codebases often change allowExplicitAny to `true`, or they disable this rule entirely.
    - By relaxing the default options, developers will be encouraged to at least add an explicit annotation, and stricter codebases can re-opt-in to banning `any`.
    - Strict codebases likely already have typescript-eslint's no-explicit-any turned on, so this shouldn't reduce practical coverage.
5. The upcoming `strict` config will set this option back to `false`. See #36 and #41 .

