### PR TITLE
feat(no-misused-observables): new rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The package includes the following rules.
 | [no-implicit-any-catch](docs/rules/no-implicit-any-catch.md)           | Disallow implicit `any` error parameters in `catchError` operators.                                       | ✅ 🔒 | 🔧 | 💡 | 💭 |    |
 | [no-index](docs/rules/no-index.md)                                     | Disallow importing index modules.                                                                         | ✅ 🔒 |    |    |    |    |
 | [no-internal](docs/rules/no-internal.md)                               | Disallow importing internal modules.                                                                      | ✅ 🔒 | 🔧 | 💡 |    |    |
-| [no-misused-observables](docs/rules/no-misused-observables.md)         | Disallow Observables in places not designed to handle them.                                               |      |    |    | 💭 |    |
+| [no-misused-observables](docs/rules/no-misused-observables.md)         | Disallow Observables in places not designed to handle them.                                               | 🔒   |    |    | 💭 |    |
 | [no-nested-subscribe](docs/rules/no-nested-subscribe.md)               | Disallow calling `subscribe` within a `subscribe` callback.                                               | ✅ 🔒 |    |    | 💭 |    |
 | [no-redundant-notify](docs/rules/no-redundant-notify.md)               | Disallow sending redundant notifications from completed or errored observables.                           | ✅ 🔒 |    |    | 💭 |    |
 | [no-sharereplay](docs/rules/no-sharereplay.md)                         | Disallow unsafe `shareReplay` usage.                                                                      | ✅ 🔒 |    |    |    |    |

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The package includes the following rules.
 | [no-implicit-any-catch](docs/rules/no-implicit-any-catch.md)           | Disallow implicit `any` error parameters in `catchError` operators.                                       | ✅ 🔒 | 🔧 | 💡 | 💭 |    |
 | [no-index](docs/rules/no-index.md)                                     | Disallow importing index modules.                                                                         | ✅ 🔒 |    |    |    |    |
 | [no-internal](docs/rules/no-internal.md)                               | Disallow importing internal modules.                                                                      | ✅ 🔒 | 🔧 | 💡 |    |    |
+| [no-misused-observables](docs/rules/no-misused-observables.md)         | Disallow Observables in places not designed to handle them.                                               |      |    |    | 💭 |    |
 | [no-nested-subscribe](docs/rules/no-nested-subscribe.md)               | Disallow calling `subscribe` within a `subscribe` callback.                                               | ✅ 🔒 |    |    | 💭 |    |
 | [no-redundant-notify](docs/rules/no-redundant-notify.md)               | Disallow sending redundant notifications from completed or errored observables.                           | ✅ 🔒 |    |    | 💭 |    |
 | [no-sharereplay](docs/rules/no-sharereplay.md)                         | Disallow unsafe `shareReplay` usage.                                                                      | ✅ 🔒 |    |    |    |    |

--- a/docs/rules/no-floating-observables.md
+++ b/docs/rules/no-floating-observables.md
@@ -19,6 +19,7 @@ This rule will report observable-valued statements that are not treated in one o
 
 > [!TIP]
 > `no-floating-observables` only detects apparently unhandled observable _statements_.
+> See [`no-misused-observables`](./no-misused-observables.md) for detecting code that provides observables to _logical_ locations
 
 ## Rule details
 

--- a/docs/rules/no-misused-observables.md
+++ b/docs/rules/no-misused-observables.md
@@ -6,14 +6,63 @@
 
 <!-- end auto-generated rule header -->
 
+This rule forbids providing observables to logical locations where the TypeScript compiler allows them but they are not handled properly.
+These situations can often arise due to a misunderstanding of the way observables are handled.
+
+> [!TIP]
+> `no-misused-observables` only detects code that provides observables to incorrect _logical_ locations.
+> See [`no-floating-observables`](./no-floating-observables.md) for detecting unhandled observable _statements_.
+
+This rule is like [no-misused-promises](https://typescript-eslint.io/rules/no-misused-promises) but for Observables.
+
+> [!NOTE]
+> Unlike `@typescript-eslint/no-misused-promises`, this rule does not check conditionals like `if` statements.
+> Use `@typescript-eslint/no-unnecessary-condition` for linting those situations.
+
+## Rule details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+import { of } from "rxjs";
+
+[1, 2, 3].forEach(i => of(i));
+
+interface MySyncInterface {
+    foo(): void;
+}
+class MyRxClass implements MySyncInterface {
+    foo(): Observable<number> {
+        return of(42);
+    }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+import { of } from "rxjs";
+
+[1, 2, 3].map(i => of(i));
+
+interface MyRxInterface {
+    foo(): Observable<number>;
+}
+class MyRxClass implements MyRxInterface {
+    foo(): Observable<number> {
+        return of(42);
+    }
+}
+```
+
 ## Options
 
 <!-- WARNING: not auto-generated! -->
 
-| Name               | Description                                                                                                                              | Type    | Default |
-| :----------------- | :--------------------------------------------------------------------------------------------------------------------------------------- | :------ | :------ |
-| `checksSpreads`    | Disallow `...` spreading an Observable.                                                                                                  | Boolean | `true`  |
-| `checksVoidReturn` | Disallow returning an Observable from a function typed as returning `void`.                                                              | Object  | `true`  |
+| Name               | Description                                                                 | Type    | Default |
+| :----------------- | :-------------------------------------------------------------------------- | :------ | :------ |
+| `checksSpreads`    | Disallow `...` spreading an Observable.                                     | Boolean | `true`  |
+| `checksVoidReturn` | Disallow returning an Observable from a function typed as returning `void`. | Object  | `true`  |
 
 ### `checksVoidReturn`
 
@@ -27,3 +76,7 @@ You can disable selective parts of the `checksVoidReturn` option. The following 
 | `properties`       | Disallow providing an Observable-returning function where a function that returns `void` is expected by a property.                      | Boolean | `true`  |
 | `returns`          | Disallow returning an Observable-returning function where a function that returns `void` is expected.                                    | Boolean | `true`  |
 | `variables`        | Disallow assigning or declaring an Observable-returning function where a function that returns `void` is expected.                       | Boolean | `true`  |
+
+## Further reading
+
+- [TypeScript void function assignability](https://github.com/Microsoft/TypeScript/wiki/FAQ#why-are-functions-returning-non-void-assignable-to-function-returning-void)

--- a/docs/rules/no-misused-observables.md
+++ b/docs/rules/no-misused-observables.md
@@ -1,0 +1,15 @@
+# Disallow Observables in places not designed to handle them (`rxjs-x/no-misused-observables`)
+
+💭 This rule requires [type information](https://typescript-eslint.io/linting/typed-linting).
+
+<!-- end auto-generated rule header -->
+
+## Options
+
+<!-- begin auto-generated rule options list -->
+
+| Name            | Description                             | Type    | Default |
+| :-------------- | :-------------------------------------- | :------ | :------ |
+| `checksSpreads` | Disallow `...` spreading an Observable. | Boolean | `true`  |
+
+<!-- end auto-generated rule options list -->

--- a/docs/rules/no-misused-observables.md
+++ b/docs/rules/no-misused-observables.md
@@ -36,6 +36,9 @@ class MyRxClass implements MySyncInterface {
         return of(42);
     }
 }
+
+const a = of(42);
+const b = { ...b };
 ```
 
 Examples of **correct** code for this rule:

--- a/docs/rules/no-misused-observables.md
+++ b/docs/rules/no-misused-observables.md
@@ -1,5 +1,7 @@
 # Disallow Observables in places not designed to handle them (`rxjs-x/no-misused-observables`)
 
+💼 This rule is enabled in the 🔒 `strict` config.
+
 💭 This rule requires [type information](https://typescript-eslint.io/linting/typed-linting).
 
 <!-- end auto-generated rule header -->

--- a/docs/rules/no-misused-observables.md
+++ b/docs/rules/no-misused-observables.md
@@ -6,11 +6,22 @@
 
 ## Options
 
-<!-- begin auto-generated rule options list -->
+<!-- WARNING: not auto-generated! -->
 
-| Name               | Description                                                                 | Type    | Default |
-| :----------------- | :-------------------------------------------------------------------------- | :------ | :------ |
-| `checksSpreads`    | Disallow `...` spreading an Observable.                                     | Boolean | `true`  |
-| `checksVoidReturn` | Disallow returning an Observable from a function typed as returning `void`. | Boolean | `true`  |
+| Name               | Description                                                                                                                              | Type    | Default |
+| :----------------- | :--------------------------------------------------------------------------------------------------------------------------------------- | :------ | :------ |
+| `checksSpreads`    | Disallow `...` spreading an Observable.                                                                                                  | Boolean | `true`  |
+| `checksVoidReturn` | Disallow returning an Observable from a function typed as returning `void`.                                                              | Object  | `true`  |
 
-<!-- end auto-generated rule options list -->
+### `checksVoidReturn`
+
+You can disable selective parts of the `checksVoidReturn` option. The following sub-options are supported:
+
+| Name               | Description                                                                                                                              | Type    | Default |
+| :----------------- | :--------------------------------------------------------------------------------------------------------------------------------------- | :------ | :------ |
+| `arguments`        | Disallow passing an Observable-returning function as an argument where the parameter type expects a function that returns `void`.        | Boolean | `true`  |
+| `attributes`       | Disallow passing an Observable-returning function as a JSX attribute expected to be a function that returns `void`.                      | Boolean | `true`  |
+| `inheritedMethods` | Disallow providing an Observable-returning function where a function that returns `void` is expected by an extended or implemented type. | Boolean | `true`  |
+| `properties`       | Disallow providing an Observable-returning function where a function that returns `void` is expected by a property.                      | Boolean | `true`  |
+| `returns`          | Disallow returning an Observable-returning function where a function that returns `void` is expected.                                    | Boolean | `true`  |
+| `variables`        | Disallow assigning or declaring an Observable-returning function where a function that returns `void` is expected.                       | Boolean | `true`  |

--- a/docs/rules/no-misused-observables.md
+++ b/docs/rules/no-misused-observables.md
@@ -8,8 +8,9 @@
 
 <!-- begin auto-generated rule options list -->
 
-| Name            | Description                             | Type    | Default |
-| :-------------- | :-------------------------------------- | :------ | :------ |
-| `checksSpreads` | Disallow `...` spreading an Observable. | Boolean | `true`  |
+| Name               | Description                                                                 | Type    | Default |
+| :----------------- | :-------------------------------------------------------------------------- | :------ | :------ |
+| `checksSpreads`    | Disallow `...` spreading an Observable.                                     | Boolean | `true`  |
+| `checksVoidReturn` | Disallow returning an Observable from a function typed as returning `void`. | Boolean | `true`  |
 
 <!-- end auto-generated rule options list -->

--- a/src/configs/strict.ts
+++ b/src/configs/strict.ts
@@ -22,6 +22,7 @@ export const createStrictConfig = (
     }],
     'rxjs-x/no-index': 'error',
     'rxjs-x/no-internal': 'error',
+    'rxjs-x/no-misused-observables': 'error',
     'rxjs-x/no-nested-subscribe': 'error',
     'rxjs-x/no-redundant-notify': 'error',
     'rxjs-x/no-sharereplay': 'error',

--- a/src/etc/get-type-services.ts
+++ b/src/etc/get-type-services.ts
@@ -38,7 +38,7 @@ export function getTypeServices<
       || ts.isMethodDeclaration(tsNode)
       || ts.isFunctionExpression(tsNode)
     ) {
-      tsTypeNode = tsNode.type ?? tsNode.body;
+      tsTypeNode = tsNode.type ?? tsNode.body; // TODO(#57): this doesn't work for Block bodies.
     } else if (
       ts.isCallSignatureDeclaration(tsNode)
       || ts.isMethodSignature(tsNode)

--- a/src/etc/get-type-services.ts
+++ b/src/etc/get-type-services.ts
@@ -44,6 +44,10 @@ export function getTypeServices<
       || ts.isMethodSignature(tsNode)
     ) {
       tsTypeNode = tsNode.type;
+    } else if (
+      ts.isPropertySignature(tsNode)
+    ) {
+      // TODO(#66): this doesn't work for functions assigned to class properties, variables, params.
     }
     return Boolean(
       tsTypeNode

--- a/src/etc/is.ts
+++ b/src/etc/is.ts
@@ -90,6 +90,10 @@ export function isMemberExpression(node: TSESTree.Node): node is TSESTree.Member
   return node.type === AST_NODE_TYPES.MemberExpression;
 }
 
+export function isMethodDefinition(node: TSESTree.Node): node is TSESTree.MethodDefinition {
+  return node.type === AST_NODE_TYPES.MethodDefinition;
+}
+
 export function isNewExpression(node: TSESTree.Node): node is TSESTree.NewExpression {
   return node.type === AST_NODE_TYPES.NewExpression;
 }
@@ -108,6 +112,10 @@ export function isProgram(node: TSESTree.Node): node is TSESTree.Program {
 
 export function isProperty(node: TSESTree.Node): node is TSESTree.Property {
   return node.type === AST_NODE_TYPES.Property;
+}
+
+export function isPropertyDefinition(node: TSESTree.Node): node is TSESTree.PropertyDefinition {
+  return node.type === AST_NODE_TYPES.PropertyDefinition;
 }
 
 export function isPrivateIdentifier(

--- a/src/etc/is.ts
+++ b/src/etc/is.ts
@@ -78,6 +78,10 @@ export function isImportSpecifier(node: TSESTree.Node): node is TSESTree.ImportS
   return node.type === AST_NODE_TYPES.ImportSpecifier;
 }
 
+export function isJSXExpressionContainer(node: TSESTree.Node): node is TSESTree.JSXExpressionContainer {
+  return node.type === AST_NODE_TYPES.JSXExpressionContainer;
+}
+
 export function isLiteral(node: TSESTree.Node): node is TSESTree.Literal {
   return node.type === AST_NODE_TYPES.Literal;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { noIgnoredTakewhileValueRule } from './rules/no-ignored-takewhile-value'
 import { noImplicitAnyCatchRule } from './rules/no-implicit-any-catch';
 import { noIndexRule } from './rules/no-index';
 import { noInternalRule } from './rules/no-internal';
+import { noMisusedObservablesRule } from './rules/no-misused-observables';
 import { noNestedSubscribeRule } from './rules/no-nested-subscribe';
 import { noRedundantNotifyRule } from './rules/no-redundant-notify';
 import { noSharereplayRule } from './rules/no-sharereplay';
@@ -74,6 +75,7 @@ const plugin = {
     'no-implicit-any-catch': noImplicitAnyCatchRule,
     'no-index': noIndexRule,
     'no-internal': noInternalRule,
+    'no-misused-observables': noMisusedObservablesRule,
     'no-nested-subscribe': noNestedSubscribeRule,
     'no-redundant-notify': noRedundantNotifyRule,
     'no-sharereplay': noSharereplayRule,

--- a/src/rules/no-misused-observables.ts
+++ b/src/rules/no-misused-observables.ts
@@ -6,6 +6,7 @@ import { ruleCreator } from '../utils';
 // https://github.com/typescript-eslint/typescript-eslint/blob/fcd6cf063a774f73ea00af23705117a197f826d4/packages/eslint-plugin/src/rules/no-misused-promises.ts
 
 const defaultOptions: readonly {
+  checksVoidReturn?: boolean;
   checksSpreads?: boolean;
 }[] = [];
 
@@ -17,11 +18,18 @@ export const noMisusedObservablesRule = ruleCreator({
       requiresTypeChecking: true,
     },
     messages: {
+      forbiddenVoidReturnArgument: 'Observable returned in function argument where a void return was expected.',
+      forbiddenVoidReturnAttribute: 'Observable-returning function provided to attribute where a void return was expected.',
+      forbiddenVoidReturnInheritedMethod: 'Observable-returning method provided where a void return was expected by extended/implemented type \'{{heritageTypeName}}\'.',
+      forbiddenVoidReturnProperty: 'Observable-returning function provided to property where a void return was expected.',
+      forbiddenVoidReturnReturnValue: 'Observable-returning function provided to return value where a void return was expected.',
+      forbiddenVoidReturnVariable: 'Observable-returning function provided to variable where a void return was expected.',
       forbiddenSpread: 'Expected a non-Observable value to be spread into an object.',
     },
     schema: [
       {
         properties: {
+          checksVoidReturn: { type: 'boolean', default: true, description: 'Disallow returning an Observable from a function typed as returning `void`.' },
           checksSpreads: { type: 'boolean', default: true, description: 'Disallow `...` spreading an Observable.' },
         },
         type: 'object',
@@ -33,7 +41,11 @@ export const noMisusedObservablesRule = ruleCreator({
   create: (context) => {
     const { couldBeObservable } = getTypeServices(context);
     const [config = {}] = context.options;
-    const { checksSpreads = true } = config;
+    const { checksVoidReturn = true, checksSpreads = true } = config;
+
+    const voidReturnChecks: TSESLint.RuleListener = {
+
+    };
 
     const spreadChecks: TSESLint.RuleListener = {
       SpreadElement: (node) => {
@@ -47,6 +59,7 @@ export const noMisusedObservablesRule = ruleCreator({
     };
 
     return {
+      ...(checksVoidReturn ? voidReturnChecks : {}),
       ...(checksSpreads ? spreadChecks : {}),
     };
   },

--- a/src/rules/no-misused-observables.ts
+++ b/src/rules/no-misused-observables.ts
@@ -53,7 +53,7 @@ export const noMisusedObservablesRule = ruleCreator({
       JSXAttribute: checkJSXAttribute,
       ClassDeclaration: checkClassLikeOrInterfaceNode,
       ClassExpression: checkClassLikeOrInterfaceNode,
-      // TSInterfaceDeclaration: checkClassLikeOrInterfaceNode,
+      TSInterfaceDeclaration: checkClassLikeOrInterfaceNode,
       // Property: checkProperty,
       // ReturnStatement: checkReturnStatement,
       // AssignmentExpression: checkAssignment,

--- a/src/rules/no-misused-observables.ts
+++ b/src/rules/no-misused-observables.ts
@@ -1,0 +1,53 @@
+import { TSESLint } from '@typescript-eslint/utils';
+import { getTypeServices } from '../etc';
+import { ruleCreator } from '../utils';
+
+// The implementation of this rule is similar to typescript-eslint's no-misused-promises. MIT License.
+// https://github.com/typescript-eslint/typescript-eslint/blob/fcd6cf063a774f73ea00af23705117a197f826d4/packages/eslint-plugin/src/rules/no-misused-promises.ts
+
+const defaultOptions: readonly {
+  checksSpreads?: boolean;
+}[] = [];
+
+export const noMisusedObservablesRule = ruleCreator({
+  defaultOptions,
+  meta: {
+    docs: {
+      description: 'Disallow Observables in places not designed to handle them.',
+      requiresTypeChecking: true,
+    },
+    messages: {
+      forbiddenSpread: 'Expected a non-Observable value to be spread into an object.',
+    },
+    schema: [
+      {
+        properties: {
+          checksSpreads: { type: 'boolean', default: true, description: 'Disallow `...` spreading an Observable.' },
+        },
+        type: 'object',
+      },
+    ],
+    type: 'problem',
+  },
+  name: 'no-misused-observables',
+  create: (context) => {
+    const { couldBeObservable } = getTypeServices(context);
+    const [config = {}] = context.options;
+    const { checksSpreads = true } = config;
+
+    const spreadChecks: TSESLint.RuleListener = {
+      SpreadElement: (node) => {
+        if (couldBeObservable(node.argument)) {
+          context.report({
+            messageId: 'forbiddenSpread',
+            node: node.argument,
+          });
+        }
+      },
+    };
+
+    return {
+      ...(checksSpreads ? spreadChecks : {}),
+    };
+  },
+});

--- a/src/rules/no-misused-observables.ts
+++ b/src/rules/no-misused-observables.ts
@@ -1,4 +1,4 @@
-import { TSESTree as es, ESLintUtils, TSESLint } from '@typescript-eslint/utils';
+import { TSESTree as es, TSESLint as eslint, ESLintUtils } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import ts from 'typescript';
 import { getTypeServices, isJSXExpressionContainer, isMethodDefinition, isPropertyDefinition } from '../etc';
@@ -47,12 +47,12 @@ export const noMisusedObservablesRule = ruleCreator({
     const [config = {}] = context.options;
     const { checksVoidReturn = true, checksSpreads = true } = config;
 
-    const voidReturnChecks: TSESLint.RuleListener = {
+    const voidReturnChecks: eslint.RuleListener = {
       CallExpression: checkArguments,
       NewExpression: checkArguments,
       JSXAttribute: checkJSXAttribute,
       ClassDeclaration: checkClassLikeOrInterfaceNode,
-      // ClassExpression: checkClassLikeOrInterfaceNode,
+      ClassExpression: checkClassLikeOrInterfaceNode,
       // TSInterfaceDeclaration: checkClassLikeOrInterfaceNode,
       // Property: checkProperty,
       // ReturnStatement: checkReturnStatement,
@@ -60,7 +60,7 @@ export const noMisusedObservablesRule = ruleCreator({
       // VariableDeclarator: checkVariableDeclarator,
     };
 
-    const spreadChecks: TSESLint.RuleListener = {
+    const spreadChecks: eslint.RuleListener = {
       SpreadElement: (node) => {
         if (couldBeObservable(node.argument)) {
           context.report({

--- a/src/rules/no-misused-observables.ts
+++ b/src/rules/no-misused-observables.ts
@@ -49,7 +49,7 @@ export const noMisusedObservablesRule = ruleCreator({
 
     const voidReturnChecks: TSESLint.RuleListener = {
       CallExpression: checkArguments,
-      // NewExpression: checkArguments,
+      NewExpression: checkArguments,
       // JSXAttribute: checkJSXAttribute,
       // ClassDeclaration: checkClassLikeOrInterfaceNode,
       // ClassExpression: checkClassLikeOrInterfaceNode,

--- a/src/rules/no-misused-observables.ts
+++ b/src/rules/no-misused-observables.ts
@@ -65,6 +65,7 @@ export const noMisusedObservablesRule = ruleCreator({
   meta: {
     docs: {
       description: 'Disallow Observables in places not designed to handle them.',
+      recommended: 'strict',
       requiresTypeChecking: true,
     },
     messages: {

--- a/src/rules/no-misused-observables.ts
+++ b/src/rules/no-misused-observables.ts
@@ -1,7 +1,7 @@
 import { TSESTree as es, ESLintUtils, TSESLint } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import ts from 'typescript';
-import { getTypeServices } from '../etc';
+import { getTypeServices, isJSXExpressionContainer } from '../etc';
 import { ruleCreator } from '../utils';
 
 // The implementation of this rule is similar to typescript-eslint's no-misused-promises. MIT License.
@@ -50,7 +50,7 @@ export const noMisusedObservablesRule = ruleCreator({
     const voidReturnChecks: TSESLint.RuleListener = {
       CallExpression: checkArguments,
       NewExpression: checkArguments,
-      // JSXAttribute: checkJSXAttribute,
+      JSXAttribute: checkJSXAttribute,
       // ClassDeclaration: checkClassLikeOrInterfaceNode,
       // ClassExpression: checkClassLikeOrInterfaceNode,
       // TSInterfaceDeclaration: checkClassLikeOrInterfaceNode,
@@ -89,6 +89,19 @@ export const noMisusedObservablesRule = ruleCreator({
             node: argument,
           });
         }
+      }
+    }
+
+    function checkJSXAttribute(node: es.JSXAttribute): void {
+      if (!node.value || !isJSXExpressionContainer(node.value)) {
+        return;
+      }
+
+      if (couldReturnObservable(node.value.expression)) {
+        context.report({
+          messageId: 'forbiddenVoidReturnAttribute',
+          node: node.value,
+        });
       }
     }
 

--- a/tests/rules/no-async-subscribe.test.ts
+++ b/tests/rules/no-async-subscribe.test.ts
@@ -3,7 +3,7 @@ import { noAsyncSubscribeRule } from '../../src/rules/no-async-subscribe';
 import { fromFixture } from '../etc';
 import { ruleTester } from '../rule-tester';
 
-ruleTester({ types: true, jsx: true }).run('no-async-subscribe', noAsyncSubscribeRule, {
+ruleTester({ types: true }).run('no-async-subscribe', noAsyncSubscribeRule, {
   valid: [
     stripIndent`
       // sync arrow function
@@ -17,12 +17,15 @@ ruleTester({ types: true, jsx: true }).run('no-async-subscribe', noAsyncSubscrib
 
       of("a").subscribe(function() {});
     `,
-    stripIndent`
-      // https://github.com/cartant/eslint-plugin-rxjs/issues/46
-      import React, { FC } from "react";
-      const SomeComponent: FC<{}> = () => <span>some component</span>;
-      const someElement = <SomeComponent />;
-    `,
+    {
+      code: stripIndent`
+        // https://github.com/cartant/eslint-plugin-rxjs/issues/46
+        import React, { FC } from "react";
+        const SomeComponent: FC<{}> = () => <span>some component</span>;
+        const someElement = <SomeComponent />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
     stripIndent`
       // https://github.com/cartant/eslint-plugin-rxjs/issues/61
       const whatever = {

--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -80,6 +80,10 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
         class Bar extends Foo {
           foo(): Observable<number> { return of(42); }
         }
+
+        const Baz = class extends Foo {
+          foo(): Observable<number> { return of(42); }
+        }
       `,
       options: [{ checksVoidReturn: false }],
     },
@@ -336,6 +340,36 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
         }
 
         class Bar extends Foo {
+          foo(): Observable<number> { return of(42); }
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Foo" }]
+        }
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return inherited method; class expression; extends
+        import { Observable, of } from "rxjs";
+
+        const Foo = class {
+          foo(): void {}
+        }
+
+        const Bar = class extends Foo {
+          foo(): Observable<number> { return of(42); }
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Foo" }]
+        }
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return inherited method; class expression; implements
+        import { Observable, of } from "rxjs";
+
+        interface Foo {
+          foo(): void;
+        }
+
+        const Bar = class implements Foo {
           foo(): Observable<number> { return of(42); }
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Foo" }]
         }

--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -1,0 +1,48 @@
+import { stripIndent } from 'common-tags';
+import { noMisusedObservablesRule } from '../../src/rules/no-misused-observables';
+import { fromFixture } from '../etc';
+import { ruleTester } from '../rule-tester';
+
+ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRule, {
+  valid: [
+    {
+      code: stripIndent`
+        // spread; explicitly allowed
+        import { of } from "rxjs";
+
+        const source = of(42);
+        const foo = { ...source };
+      `,
+      options: [{ checksSpreads: false }],
+    },
+    stripIndent`
+      // unrelated
+      const foo = { bar: 42 };
+      const baz = { ...foo };
+    `,
+  ],
+  invalid: [
+    fromFixture(
+      stripIndent`
+        // spread variable
+        import { of } from "rxjs";
+
+        const source = of(42);
+        const foo = { ...source };
+                         ~~~~~~ [forbiddenSpread]
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // spread call function
+        import { of } from "rxjs";
+
+        function source() {
+          return of(42);
+        }
+        const foo = { ...source() };
+                         ~~~~~~~~ [forbiddenSpread]
+      `,
+    ),
+  ],
+});

--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -213,6 +213,7 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
 
         let foo: () => void;
         foo = (): Observable<number> => of(42);
+        const bar: () => void = (): Observable<number> => of(42);
       `,
       options: [{ checksVoidReturn: false }],
     },
@@ -754,6 +755,17 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
         let foo: () => void;
         foo = () => of(42);
               ~~~~~~~~~~~~ [forbiddenVoidReturnVariable]
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return variable; const
+        import { of } from "rxjs";
+
+        const foo: () => void = () => of(42);
+                                ~~~~~~~~~~~~ [forbiddenVoidReturnVariable]
+        const bar = () => of(42), baz: () => void = () => of(42);
+                                                    ~~~~~~~~~~~~ [forbiddenVoidReturnVariable]
       `,
     ),
     fromFixture(

--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -205,6 +205,30 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
       }
     `,
     // #endregion valid; void return return value
+    // #region valid; void return variable
+    {
+      code: stripIndent`
+        // void return variable; explicitly allowed
+        import { Observable, of } from "rxjs";
+
+        let foo: () => void;
+        foo = (): Observable<number> => of(42);
+      `,
+      options: [{ checksVoidReturn: false }],
+    },
+    stripIndent`
+      // void return variable; not void
+      import { Observable, of } from "rxjs";
+
+      let foo: () => Observable<number>;
+      foo = () => of(42);
+    `,
+    stripIndent`
+      // void return variable; unrelated
+      let foo: () => void;
+      foo = (): number => 42;
+    `,
+    // #endregion valid; void return variable
     // #region valid; spread
     {
       code: stripIndent`
@@ -721,6 +745,40 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
       `,
     ),
     // #endregion invalid; void return return value
+    // #region invalid; void return variable
+    fromFixture(
+      stripIndent`
+        // void return variable; reassign
+        import { of } from "rxjs";
+
+        let foo: () => void;
+        foo = () => of(42);
+              ~~~~~~~~~~~~ [forbiddenVoidReturnVariable]
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return variable; nested
+        import { of } from "rxjs";
+
+        const foo: {
+          bar?: () => void;
+        } = {};
+        foo.bar = () => of(42);
+                  ~~~~~~~~~~~~ [forbiddenVoidReturnVariable]
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return variable; Record
+        import { of } from "rxjs";
+
+        const foo: Record<string, () => void> = {};
+        foo.bar = () => of(42);
+                  ~~~~~~~~~~~~ [forbiddenVoidReturnVariable]
+      `,
+    ),
+    // #endregion invalid; void return variable
     // #region invalid; spread
     fromFixture(
       stripIndent`

--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -7,6 +7,27 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
   valid: [
     {
       code: stripIndent`
+        // void return argument; explicitly allowed
+        import { Observable, of } from "rxjs";
+
+        [1, 2, 3].forEach((i): Observable<number> => { return of(i); });
+        [1, 2, 3].forEach(i => of(i));
+      `,
+      options: [{ checksVoidReturn: false }],
+    },
+    stripIndent`
+      // void return argument; unrelated
+      [1, 2, 3].forEach(i => i);
+      [1, 2, 3].forEach(i => { return i; });
+    `,
+    stripIndent`
+      // couldReturnType is bugged for block body implicit return types (#57)
+      import { of } from "rxjs";
+
+      [1, 2, 3].forEach(i => { return of(i); });
+    `,
+    {
+      code: stripIndent`
         // spread; explicitly allowed
         import { of } from "rxjs";
 
@@ -16,12 +37,48 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
       options: [{ checksSpreads: false }],
     },
     stripIndent`
-      // unrelated
+      // spread; unrelated
       const foo = { bar: 42 };
       const baz = { ...foo };
     `,
   ],
   invalid: [
+    fromFixture(
+      stripIndent`
+        // void return argument; block body
+        import { Observable, of } from "rxjs";
+
+        [1, 2, 3].forEach((i): Observable<number> => { return of(i); });
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnArgument]
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return argument; inline body
+        import { of } from "rxjs";
+
+        [1, 2, 3].forEach(i => of(i));
+                          ~~~~~~~~~~ [forbiddenVoidReturnArgument]
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return argument; block body; union return
+        import { Observable, of } from "rxjs";
+
+        [1, 2, 3].forEach((i): Observable<number> | number => { if (i > 1) { return of(i); } else { return i; } });
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnArgument]
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return argument; inline body; union return
+        import { of } from "rxjs";
+
+        [1, 2, 3].forEach(i => i > 1 ? of(i) : i);
+                          ~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnArgument]
+      `,
+    ),
     fromFixture(
       stripIndent`
         // spread variable

--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -67,6 +67,33 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
       languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
     },
     // #endregion valid; void return attribute
+    // #region valid; void return inherited method
+    {
+      code: stripIndent`
+        // void return inherited method; explicitly allowed
+        import { Observable, of } from "rxjs";
+
+        class Foo {
+          foo(): void {}
+        }
+
+        class Bar extends Foo {
+          foo(): Observable<number> { return of(42); }
+        }
+      `,
+      options: [{ checksVoidReturn: false }],
+    },
+    stripIndent`
+      // void return inherited method; unrelated
+      class Foo {
+        foo(): void {}
+      }
+
+      class Bar extends Foo {
+        foo(): number { return 42; }
+      }
+    `,
+    // #endregion valid; void return inherited method
     // #region valid; spread
     {
       code: stripIndent`
@@ -170,6 +197,151 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
       },
     ),
     // #endregion invalid; void return attribute
+    // #region invalid; void return inherited method
+    fromFixture(
+      stripIndent`
+        // void return inherited method; class declaration; extends
+        import { Observable, of } from "rxjs";
+
+        class Foo {
+          foo(): void {}
+        }
+
+        class Bar extends Foo {
+          foo(): Observable<number> { return of(42); }
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Foo" }]
+        }
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return inherited method; class declaration; abstract extends
+        import { Observable } from "rxjs";
+
+        class Foo {
+          foo(): void {}
+        }
+
+        abstract class Bar extends Foo {
+          abstract foo(): Observable<number>;
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Foo" }]
+        }
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return inherited method; class declaration; extends abstract
+        import { Observable, of } from "rxjs";
+
+        abstract class Foo {
+          abstract foo(): void;
+        }
+
+        class Bar extends Foo {
+          foo(): Observable<number> { return of(42); }
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Foo" }]
+        }
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return inherited method; class declaration; abstract extends abstract
+        import { Observable } from "rxjs";
+
+        abstract class Foo {
+          abstract foo(): void;
+        }
+
+        abstract class Bar extends Foo {
+          abstract foo(): Observable<number>;
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Foo" }]
+        }
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return inherited method; class declaration; implements
+        import { Observable, of } from "rxjs";
+
+        interface Foo {
+          foo(): void;
+        }
+
+        class Bar implements Foo {
+          foo(): Observable<number> { return of(42); }
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Foo" }]
+        }
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return inherited method; class declaration; abstract implements
+        import { Observable } from "rxjs";
+
+        interface Foo {
+          foo(): void;
+        }
+
+        abstract class Bar implements Foo {
+          abstract foo(): Observable<number>;
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Foo" }]
+        }
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return inherited method; class declaration; implements type intersection
+        import { Observable, of } from "rxjs";
+
+        type Foo = { foo(): void } & { bar(): void };
+
+        class Bar implements Foo {
+          foo(): Observable<number> { return of(42); }
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Foo" }]
+          bar(): void {}
+        }
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return inherited method; class declaration; extends and implements
+        import { Observable, of } from "rxjs";
+
+        interface Foo {
+          foo(): Observable<void>;
+        }
+
+        interface Bar {
+          foo(): void;
+        }
+
+        class Baz {
+          foo(): void {}
+        }
+
+        class Qux extends Baz implements Foo, Bar {
+          foo(): Observable<void> { return of(42); }
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Baz" }]
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Bar" }]
+        }
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return inherited method; class declaration; extends class expression
+        import { Observable, of } from "rxjs";
+
+        const Foo = class {
+          foo(): void {}
+        }
+
+        class Bar extends Foo {
+          foo(): Observable<number> { return of(42); }
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Foo" }]
+        }
+      `,
+    ),
+    // #endregion invalid; void return inherited method
     // #region invalid; spread
     fromFixture(
       stripIndent`

--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -19,7 +19,7 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
         }
         new Foo(() => of(42));
       `,
-      options: [{ checksVoidReturn: false }],
+      options: [{ checksVoidReturn: { arguments: false } }],
     },
     stripIndent`
       // void return argument; unrelated
@@ -53,7 +53,7 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
           );
         };
       `,
-      options: [{ checksVoidReturn: false }],
+      options: [{ checksVoidReturn: { attributes: false } }],
       languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
     },
     {
@@ -93,7 +93,7 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
           foo(): Observable<number>;
         }
       `,
-      options: [{ checksVoidReturn: false }],
+      options: [{ checksVoidReturn: { inheritedMethods: false } }],
     },
     stripIndent`
       // void return inherited method; not void
@@ -140,7 +140,7 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
           c(): Observable<number> { return of(42); },
         };
       `,
-      options: [{ checksVoidReturn: false }],
+      options: [{ checksVoidReturn: { properties: false } }],
     },
     stripIndent`
       // void return property; not void
@@ -185,7 +185,7 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
           return (): Observable<number> => of(42);
         }
       `,
-      options: [{ checksVoidReturn: false }],
+      options: [{ checksVoidReturn: { returns: false } }],
     },
     stripIndent`
       // void return return value; not void
@@ -215,7 +215,7 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
         foo = (): Observable<number> => of(42);
         const bar: () => void = (): Observable<number> => of(42);
       `,
-      options: [{ checksVoidReturn: false }],
+      options: [{ checksVoidReturn: { variables: false } }],
     },
     stripIndent`
       // void return variable; not void

--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -12,6 +12,11 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
 
         [1, 2, 3].forEach((i): Observable<number> => { return of(i); });
         [1, 2, 3].forEach(i => of(i));
+
+        class Foo {
+          constructor(x: () => void) {}
+        }
+        new Foo(() => of(42));
       `,
       options: [{ checksVoidReturn: false }],
     },
@@ -19,6 +24,12 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
       // void return argument; unrelated
       [1, 2, 3].forEach(i => i);
       [1, 2, 3].forEach(i => { return i; });
+
+      class Foo {
+        constructor(x: () => void) {}
+      }
+      new Foo(() => 42);
+      new Foo;
     `,
     stripIndent`
       // couldReturnType is bugged for block body implicit return types (#57)
@@ -77,6 +88,18 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
 
         [1, 2, 3].forEach(i => i > 1 ? of(i) : i);
                           ~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnArgument]
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return argument; constructor
+        import { of } from "rxjs";
+
+        class Foo {
+          constructor(x: () => void) {}
+        }
+        new Foo(() => of(42));
+                ~~~~~~~~~~~~ [forbiddenVoidReturnArgument]
       `,
     ),
     fromFixture(

--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -5,6 +5,7 @@ import { ruleTester } from '../rule-tester';
 
 ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRule, {
   valid: [
+    // #region valid; void return argument
     {
       code: stripIndent`
         // void return argument; explicitly allowed
@@ -37,6 +38,8 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
 
       [1, 2, 3].forEach(i => { return of(i); });
     `,
+    // #endregion valid; void return argument
+    // #region valid; void return attribute
     {
       code: stripIndent`
         // void return attribute; explicitly allowed
@@ -63,6 +66,8 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
       `,
       languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
     },
+    // #endregion valid; void return attribute
+    // #region valid; spread
     {
       code: stripIndent`
         // spread; explicitly allowed
@@ -78,8 +83,10 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
       const foo = { bar: 42 };
       const baz = { ...foo };
     `,
+    // #endregion valid; spread
   ],
   invalid: [
+    // #region invalid; void return argument
     fromFixture(
       stripIndent`
         // void return argument; block body
@@ -128,6 +135,8 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
                 ~~~~~~~~~~~~ [forbiddenVoidReturnArgument]
       `,
     ),
+    // #endregion invalid; void return argument
+    // #region invalid; void return attribute
     fromFixture(
       stripIndent`
         // void return attribute; block body
@@ -160,6 +169,8 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
         languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
       },
     ),
+    // #endregion invalid; void return attribute
+    // #region invalid; spread
     fromFixture(
       stripIndent`
         // spread variable
@@ -182,5 +193,6 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
                          ~~~~~~~~ [forbiddenSpread]
       `,
     ),
+    // #endregion invalid; spread
   ],
 });

--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -39,6 +39,32 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
     `,
     {
       code: stripIndent`
+        // void return attribute; explicitly allowed
+        import { Observable, of } from "rxjs";
+        import React, { FC } from "react";
+
+        const Component: FC<{ foo: () => void }> = () => <div />;
+        return (
+          <Component foo={() => of(42)} />
+        );
+      `,
+      options: [{ checksVoidReturn: false }],
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: stripIndent`
+        // void return attribute; unrelated
+        import React, { FC } from "react";
+
+        const Component: FC<{ foo: () => void }> = () => <div />;
+        return (
+          <Component foo={() => 42} />
+        );
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: stripIndent`
         // spread; explicitly allowed
         import { of } from "rxjs";
 
@@ -101,6 +127,38 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
         new Foo(() => of(42));
                 ~~~~~~~~~~~~ [forbiddenVoidReturnArgument]
       `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return attribute; block body
+        import { Observable, of } from "rxjs";
+        import React, { FC } from "react";
+
+        const Component: FC<{ foo: () => void }> = () => <div />;
+        return (
+          <Component foo={(): Observable<number> => { return of(42); }} />
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnAttribute]
+        );
+      `,
+      {
+        languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+      },
+    ),
+    fromFixture(
+      stripIndent`
+        // void return attribute; inline body
+        import { Observable, of } from "rxjs";
+        import React, { FC } from "react";
+
+        const Component: FC<{ foo: () => void }> = () => <div />;
+        return (
+          <Component foo={() => of(42)} />
+                         ~~~~~~~~~~~~~~ [forbiddenVoidReturnAttribute]
+        );
+      `,
+      {
+        languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+      },
     ),
     fromFixture(
       stripIndent`


### PR DESCRIPTION
New rule based on `@typescript-eslint/no-misused-promises`.  Ensures you don't return an Observable where void is expected, or try to spread an Observable.  This rule is added to the `strict` configuration.

Resolves #43 .

Note: `checksVoidReturn` is noticeably slow, specifically stemming from the `arguments`, `properties`, and `variables` sub-options.  It's still faster than `@typescript-eslint/no-deprecated` and some `import-x` rules, but it's in the top 10 with `TIMING=1` enabled.  But since the implementation is similar to `@typescript-eslint/no-misused-promises` which has similar performance, we'll allow it.