### PR TITLE
feat(deps)!: bump minimum TypeScript to 4.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0",
     "rxjs": ">=7.2.0",
-    "typescript": ">=4.7.4"
+    "typescript": ">=4.8.4"
   },
   "peerDependenciesMeta": {
     "rxjs": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1962,7 +1962,7 @@ __metadata:
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     rxjs: ">=7.2.0"
-    typescript: ">=4.7.4"
+    typescript: ">=4.8.4"
   peerDependenciesMeta:
     rxjs:
       optional: true


### PR DESCRIPTION
BREAKING CHANGE: TypeScript <4.8.4 is no longer supported.

typescript-eslint v8 [dropped support](https://typescript-eslint.io/blog/announcing-typescript-eslint-v8/#tooling-breaking-changes) for TypeScript <4.8.4, and `ts-api-utils` recently did the same in a v2 release.  We are mirroring that change.