### PR TITLE
chore(dependabot): don't update node types automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,14 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
     allow:
       - dependency-type: development
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
     versioning-strategy: increase
     groups:
       vitest:


### PR DESCRIPTION
We're keeping node types in line with the lowest supported Node.js version, so dependabot should ignore all but patch updates.

Also bump PR limit to 10.