### PR TITLE
feat: add `name` to each configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "lint",
     "rules",
     "eslint",
+    "eslintplugin",
+    "eslint-plugin",
     "rxjs"
   ],
   "sideEffects": false,

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -3,6 +3,7 @@ import { TSESLint } from '@typescript-eslint/utils';
 export const createRecommendedConfig = (
   plugin: TSESLint.FlatConfig.Plugin,
 ) => ({
+  name: 'rxjs-x/recommended' as const,
   plugins: {
     'rxjs-x': plugin,
   },

--- a/src/configs/strict.ts
+++ b/src/configs/strict.ts
@@ -3,6 +3,7 @@ import { TSESLint } from '@typescript-eslint/utils';
 export const createStrictConfig = (
   plugin: TSESLint.FlatConfig.Plugin,
 ) => ({
+  name: 'rxjs-x/strict' as const,
   plugins: {
     'rxjs-x': plugin,
   },

--- a/tests/configs/recommended.test.ts
+++ b/tests/configs/recommended.test.ts
@@ -14,4 +14,8 @@ describe('recommended', () => {
       expect(ruleEntry).toEqual('error');
     }
   });
+
+  it('should be named', () => {
+    expect(config.name).toEqual('rxjs-x/recommended');
+  });
 });

--- a/tests/configs/strict.test.ts
+++ b/tests/configs/strict.test.ts
@@ -16,4 +16,8 @@ describe('strict', () => {
       expect(config.rules).toHaveProperty(rule);
     }
   });
+
+  it('should be named', () => {
+    expect(config.name).toEqual('rxjs-x/strict');
+  });
 });


### PR DESCRIPTION
[Configuration name is optional but recommended](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions).  The old eslintrc format does not support name, but since we don't support eslintrc, we're ok to add `name`.

- Add `name` to recommended and strict configurations.  Enforce via unit test.
- Also add more keywords to the npm package as recommended by eslint.org.