### PR TITLE
feat(strict): remove no-explicit-generics from `strict`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The package includes the following rules.
 | [no-connectable](docs/rules/no-connectable.md)                         | Disallow operators that return connectable observables.                                                   |      |    |    | 💭 |    |
 | [no-create](docs/rules/no-create.md)                                   | Disallow the static `Observable.create` function.                                                         | ✅ 🔒 |    |    | 💭 |    |
 | [no-cyclic-action](docs/rules/no-cyclic-action.md)                     | Disallow cyclic actions in effects and epics.                                                             |      |    |    | 💭 |    |
-| [no-explicit-generics](docs/rules/no-explicit-generics.md)             | Disallow unnecessary explicit generic type arguments.                                                     | 🔒   |    |    |    |    |
+| [no-explicit-generics](docs/rules/no-explicit-generics.md)             | Disallow unnecessary explicit generic type arguments.                                                     |      |    |    |    |    |
 | [no-exposed-subjects](docs/rules/no-exposed-subjects.md)               | Disallow public and protected subjects.                                                                   | 🔒   |    |    | 💭 |    |
 | [no-finnish](docs/rules/no-finnish.md)                                 | Disallow Finnish notation.                                                                                |      |    |    | 💭 |    |
 | [no-floating-observables](docs/rules/no-floating-observables.md)       | Require Observables to be handled appropriately.                                                          | 🔒   |    |    | 💭 |    |

--- a/docs/rules/no-explicit-generics.md
+++ b/docs/rules/no-explicit-generics.md
@@ -19,3 +19,7 @@ Examples of **correct** code for this rule:
 import { BehaviorSubject } from "rxjs";
 const subject = new BehaviorSubject(42);
 ```
+
+## Known problems
+
+- ([#77](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/issues/77)) Type unions cause false positives e.g. `new BehaviorSubject<number | null>(null)` will be incorrectly caught by this rule.

--- a/docs/rules/no-explicit-generics.md
+++ b/docs/rules/no-explicit-generics.md
@@ -1,7 +1,5 @@
 # Disallow unnecessary explicit generic type arguments (`rxjs-x/no-explicit-generics`)
 
-💼 This rule is enabled in the 🔒 `strict` config.
-
 <!-- end auto-generated rule header -->
 
 This rule prevents the use of explicit type arguments when the type arguments can be inferred.

--- a/src/configs/strict.ts
+++ b/src/configs/strict.ts
@@ -10,7 +10,6 @@ export const createStrictConfig = (
   rules: {
     'rxjs-x/no-async-subscribe': 'error',
     'rxjs-x/no-create': 'error',
-    'rxjs-x/no-explicit-generics': 'error',
     'rxjs-x/no-exposed-subjects': 'error',
     'rxjs-x/no-floating-observables': 'error',
     'rxjs-x/no-ignored-default-value': 'error',

--- a/src/rules/no-explicit-generics.ts
+++ b/src/rules/no-explicit-generics.ts
@@ -7,7 +7,6 @@ export const noExplicitGenericsRule = ruleCreator({
   meta: {
     docs: {
       description: 'Disallow unnecessary explicit generic type arguments.',
-      recommended: 'strict',
     },
     messages: {
       forbidden: 'Explicit generic type arguments are forbidden.',


### PR DESCRIPTION
There are known problems with this rule (#77), so we're removing it to avoid unnecessary problems for now.