### PR TITLE
chore(license): add new copyright line

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2019 Nicholas Jamieson and contributors
-Copyright (c) 2024 Jason Weinzierl <https://github.com/JasonWeinzierl> and contributors
+Copyright (c) 2024 Jason Weinzierl and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2019 Nicholas Jamieson and contributors, 2024-PRESENT Jason Weinzierl <https://github.com/JasonWeinzierl>
+Copyright (c) 2019 Nicholas Jamieson and contributors
+Copyright (c) 2024 Jason Weinzierl <https://github.com/JasonWeinzierl> and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
When originally forked, we appended text to the copyright notice in `LICENSE`.
It's more proper to add a new line instead of modifying the old one.
Also removing the webpage link as unnecessary.

Resolves #101