### PR TITLE
docs(no-subject-unsubscribe): document add ban

### DIFF
--- a/docs/rules/no-subject-unsubscribe.md
+++ b/docs/rules/no-subject-unsubscribe.md
@@ -9,6 +9,38 @@
 This rule effects failures if the `unsubscribe` method is called on subjects.
 The method behaves differently to the `unsubscribe` method on subscriptions and is often an error.
 
+This rule also effects failures if a subject is passed to a subscription's `add` method.
+Adding a subject to a subscription will cause the subject's `unsubscribe` method to get called
+when the subscription is unsubscribed.
+
+## Rule details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+import { Subject } from "rxjs";
+
+const subject = new Subject<number>();
+subject.unsubscribe();
+```
+
+```ts
+import { Subject, Subscription } from "rxjs";
+
+const subject = new Subject<number>();
+const subscription = new Subscription();
+subscription.add(subject);
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+import { Subject } from "rxjs";
+
+const subject = new Subject<number>();
+subject.complete();
+```
+
 ## When Not To Use It
 
 If you intentionally use `unsubscribe` to cause errors when subjects are `next`-ed after closing,
@@ -19,6 +51,7 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 ## Further reading
 
 - [Closed Subjects](https://ncjamieson.com/closed-subjects/)
+- [Composing Subscription](https://ncjamieson.com/composing-subscriptions/)
 
 ## Related To
 


### PR DESCRIPTION
Adds documentation about previously undocumented (but tested) behavior.  Also adds rule details for this rule.