### PR TITLE
feat(no-topromise): suggest an exact replacement for toPromise()

### DIFF
--- a/docs/rules/no-topromise.md
+++ b/docs/rules/no-topromise.md
@@ -10,9 +10,10 @@
 
 This rule effects failures if the `toPromise` method is used.
 
-This rule provides two editor suggestions which replace `toPromise` with either:
+This rule provides three editor suggestions which replace `toPromise` with either:
 
-- `lastValueFrom(...)`, which behaves closest to the behavior of `toPromise`,
+- `lastValueFrom(..., { defaultValue: undefined })`, which imitates the behavior of `toPromise`,
+- or `lastValueFrom(...)`, which throws `EmptyError` instead of defaulting to `undefined`,
 - or `firstValueFrom(...)`.
 
 ## When Not To Use It
@@ -25,6 +26,10 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 ## Further reading
 
 - [Conversion to Promises](https://rxjs.dev/deprecations/to-promise)
+
+## Related To
+
+- [`no-ignored-default-value`](./no-ignored-default-value.md)
 
 ## Resources
 

--- a/src/rules/no-topromise.ts
+++ b/src/rules/no-topromise.ts
@@ -13,6 +13,7 @@ export const noTopromiseRule = ruleCreator({
     hasSuggestions: true,
     messages: {
       forbidden: 'The toPromise method is forbidden.',
+      suggestLastValueFromWithDefault: 'Use lastValueFrom(..., { defaultValue: undefined }) instead.',
       suggestLastValueFrom: 'Use lastValueFrom instead.',
       suggestFirstValueFrom: 'Use firstValueFrom instead.',
     },
@@ -37,6 +38,7 @@ export const noTopromiseRule = ruleCreator({
       callExpression: es.CallExpression,
       observableNode: es.Node,
       importDeclarations: es.ImportDeclaration[],
+      { withDefault }: { withDefault?: boolean } = {},
     ) {
       return function* fix(fixer: TSESLint.RuleFixer) {
         let namespace = '';
@@ -74,7 +76,7 @@ export const noTopromiseRule = ruleCreator({
 
         yield fixer.replaceText(
           callExpression,
-          `${namespace}${functionName}(${context.sourceCode.getText(observableNode)})`,
+          `${namespace}${functionName}(${context.sourceCode.getText(observableNode)}${withDefault ? ', { defaultValue: undefined }' : ''})`,
         );
       };
     }
@@ -99,6 +101,10 @@ export const noTopromiseRule = ruleCreator({
           messageId: 'forbidden',
           node: memberExpression.property,
           suggest: [
+            {
+              messageId: 'suggestLastValueFromWithDefault',
+              fix: createFix('lastValueFrom', node, memberExpression.object, importDeclarations, { withDefault: true }),
+            },
             {
               messageId: 'suggestLastValueFrom',
               fix: createFix('lastValueFrom', node, memberExpression.object, importDeclarations),

--- a/tests/rules/no-topromise.test.ts
+++ b/tests/rules/no-topromise.test.ts
@@ -38,10 +38,19 @@ ruleTester({ types: true }).run('no-topromise', noTopromiseRule, {
         import { of } from "rxjs";
         const a = of("a");
         a.toPromise().then(value => console.log(value));
-          ~~~~~~~~~ [forbidden suggest 0 1]
+          ~~~~~~~~~ [forbidden suggest 0 1 2]
       `,
       {
         suggestions: [
+          {
+            messageId: 'suggestLastValueFromWithDefault',
+            output: stripIndent`
+              // observable toPromise
+              import { of, lastValueFrom } from "rxjs";
+              const a = of("a");
+              lastValueFrom(a, { defaultValue: undefined }).then(value => console.log(value));
+            `,
+          },
           {
             messageId: 'suggestLastValueFrom',
             output: stripIndent`
@@ -69,10 +78,19 @@ ruleTester({ types: true }).run('no-topromise', noTopromiseRule, {
         import { Subject } from "rxjs";
         const a = new Subject<string>();
         a.toPromise().then(value => console.log(value));
-          ~~~~~~~~~ [forbidden suggest 0 1]
+          ~~~~~~~~~ [forbidden suggest 0 1 2]
       `,
       {
         suggestions: [
+          {
+            messageId: 'suggestLastValueFromWithDefault',
+            output: stripIndent`
+              // subject toPromise
+              import { Subject, lastValueFrom } from "rxjs";
+              const a = new Subject<string>();
+              lastValueFrom(a, { defaultValue: undefined }).then(value => console.log(value));
+            `,
+          },
           {
             messageId: 'suggestLastValueFrom',
             output: stripIndent`
@@ -102,11 +120,22 @@ ruleTester({ types: true }).run('no-topromise', noTopromiseRule, {
         a
           .foo$
           .toPromise().then(value => console.log(value))
-           ~~~~~~~~~ [forbidden suggest 0 1]
+           ~~~~~~~~~ [forbidden suggest 0 1 2]
           .catch(error => console.error(error));
       `,
       {
         suggestions: [
+          {
+            messageId: 'suggestLastValueFromWithDefault',
+            output: stripIndent`
+              // weird whitespace
+              import { of, lastValueFrom } from "rxjs";
+              const a = { foo$: of("a") };
+              lastValueFrom(a
+                .foo$, { defaultValue: undefined }).then(value => console.log(value))
+                .catch(error => console.error(error));
+            `,
+          },
           {
             messageId: 'suggestLastValueFrom',
             output: stripIndent`
@@ -138,10 +167,19 @@ ruleTester({ types: true }).run('no-topromise', noTopromiseRule, {
         import { lastValueFrom as lvf, of } from "rxjs";
         const a = of("a");
         a.toPromise().then(value => console.log(value));
-          ~~~~~~~~~ [forbidden suggest 0 1]
+          ~~~~~~~~~ [forbidden suggest 0 1 2]
       `,
       {
         suggestions: [
+          {
+            messageId: 'suggestLastValueFromWithDefault',
+            output: stripIndent`
+              // lastValueFrom already imported
+              import { lastValueFrom as lvf, of } from "rxjs";
+              const a = of("a");
+              lvf(a, { defaultValue: undefined }).then(value => console.log(value));
+            `,
+          },
           {
             messageId: 'suggestLastValueFrom',
             output: stripIndent`
@@ -170,10 +208,21 @@ ruleTester({ types: true }).run('no-topromise', noTopromiseRule, {
 
         const a = fromFetch("https://api.some.com");
         a.toPromise().then(value => console.log(value));
-          ~~~~~~~~~ [forbidden suggest 0 1]
+          ~~~~~~~~~ [forbidden suggest 0 1 2]
       `,
       {
         suggestions: [
+          {
+            messageId: 'suggestLastValueFromWithDefault',
+            output: stripIndent`
+              // rxjs not already imported
+              import { fromFetch } from "rxjs/fetch";
+              import { lastValueFrom } from "rxjs";
+
+              const a = fromFetch("https://api.some.com");
+              lastValueFrom(a, { defaultValue: undefined }).then(value => console.log(value));
+            `,
+          },
           {
             messageId: 'suggestLastValueFrom',
             output: stripIndent`
@@ -205,10 +254,19 @@ ruleTester({ types: true }).run('no-topromise', noTopromiseRule, {
         import * as Rx from "rxjs";
         const a = Rx.of("a");
         a.toPromise().then(value => console.log(value));
-          ~~~~~~~~~ [forbidden suggest 0 1]
+          ~~~~~~~~~ [forbidden suggest 0 1 2]
       `,
       {
         suggestions: [
+          {
+            messageId: 'suggestLastValueFromWithDefault',
+            output: stripIndent`
+              // namespace import
+              import * as Rx from "rxjs";
+              const a = Rx.of("a");
+              Rx.lastValueFrom(a, { defaultValue: undefined }).then(value => console.log(value));
+            `,
+          },
           {
             messageId: 'suggestLastValueFrom',
             output: stripIndent`


### PR DESCRIPTION
This adds the "most correct" suggestion to `no-topromise` for replacing `toPromise()`.

The old `toPromise()` would resolve to `undefined`, while the new `lastValueFrom` rejects with `EmptyError`. So if a user followed the old top suggestion and replaced `toPromise` with `lastValueFrom`, they might be surprised to find `EmptyError` now thrown instead. This wouldn't be a problem for someone using the `strict` config, which includes `no-ignored-default-value`, but users of the `recommended` config wouldn't get that lint notification.

Resolves #168