### PR TITLE
fix: check functions with implicit return types

### DIFF
--- a/src/etc/get-type-services.ts
+++ b/src/etc/get-type-services.ts
@@ -38,7 +38,16 @@ export function getTypeServices<
       || ts.isMethodDeclaration(tsNode)
       || ts.isFunctionExpression(tsNode)
     ) {
-      tsTypeNode = tsNode.type ?? tsNode.body; // TODO(#57): this doesn't work for Block bodies.
+      if (tsNode.type) {
+        tsTypeNode = tsNode.type;
+      } else if (tsNode.body && ts.isBlock(tsNode.body)) {
+        const returnStatement = tsNode.body.statements.find(ts.isReturnStatement);
+        if (returnStatement?.expression) {
+          tsTypeNode = returnStatement.expression;
+        }
+      } else {
+        tsTypeNode = tsNode.body;
+      }
     } else if (
       ts.isCallSignatureDeclaration(tsNode)
       || ts.isMethodSignature(tsNode)

--- a/tests/rules/finnish.test.ts
+++ b/tests/rules/finnish.test.ts
@@ -23,6 +23,7 @@ ruleTester({ types: true }).run('finnish', finnishRule, {
         someArray.forEach((element$: Observable<any>) => {});
 
         function someFunction$(someParam$: Observable<any>): Observable<any> { return someParam; }
+        function someImplicitReturnFunction$(someParam$: Observable<any>) { return someParam; }
 
         class SomeClass {
           someProperty$: Observable<any>;
@@ -30,6 +31,7 @@ ruleTester({ types: true }).run('finnish', finnishRule, {
           get someGetter$(): Observable<any> { throw new Error("Some error."); }
           set someSetter$(someParam$: Observable<any>) {}
           someMethod$(someParam$: Observable<any>): Observable<any> { return someParam; }
+          someImplicitReturnMethod$(someParam$: Observable<any>) { return someParam; }
         }
 
         interface SomeInterface {
@@ -131,6 +133,7 @@ ruleTester({ types: true }).run('finnish', finnishRule, {
         const someObservable$ = of(0);
         const someArray = [someObservable$];
         function someFunction(someParam$: Observable<any>): Observable<any> { return someParam$; }
+        function someImplicitReturnFunction(someParam$: Observable<any>) { return someParam$; }
       `,
       options: [{ functions: false }],
     },
@@ -141,6 +144,7 @@ ruleTester({ types: true }).run('finnish', finnishRule, {
 
         class SomeClass {
           someMethod(someParam$: Observable<any>): Observable<any> { return someParam$; }
+          someImplicitReturnMethod(someParam$: Observable<any>) { return someParam$; }
         }
 
         interface SomeInterface {
@@ -269,6 +273,8 @@ ruleTester({ types: true }).run('finnish', finnishRule, {
         const someArray = [someObservable$];
         function someFunction(someParam$: Observable<any>): Observable<any> { return someParam$; }
                  ~~~~~~~~~~~~ [shouldBeFinnish]
+        function someImplicitReturnFunction(someParam$: Observable<any>) { return someParam$; }
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~ [shouldBeFinnish]
       `,
     ),
     fromFixture(
@@ -279,6 +285,8 @@ ruleTester({ types: true }).run('finnish', finnishRule, {
         class SomeClass {
           someMethod(someParam$: Observable<any>): Observable<any> { return someParam$; }
           ~~~~~~~~~~ [shouldBeFinnish]
+          someImplicitReturnMethod(someParam$: Observable<any>) { return someParam$; }
+          ~~~~~~~~~~~~~~~~~~~~~~~~ [shouldBeFinnish]
         }
 
         interface SomeInterface {
@@ -413,6 +421,8 @@ ruleTester({ types: true }).run('finnish', finnishRule, {
         class SomeClass {
           someMethod(someValue: any): Observable<any> { return of(someValue); }
           ~~~~~~~~~~ [shouldBeFinnish]
+          someImplicitReturnMethod(someValue: any) { return of(someValue); }
+          ~~~~~~~~~~~~~~~~~~~~~~~~ [shouldBeFinnish]
         }
 
         interface SomeInterface {

--- a/tests/rules/no-finnish.test.ts
+++ b/tests/rules/no-finnish.test.ts
@@ -119,6 +119,10 @@ ruleTester({ types: true }).run('no-finnish', noFinnishRule, {
           someMethod$(someParam$: Observable<any>): Observable<any> { return someParam; }
           ~~~~~~~~~~~ [forbidden]
                       ~~~~~~~~~~ [forbidden]
+          someImplicitReturnMethod$(someParam: Observable<any>) {
+          ~~~~~~~~~~~~~~~~~~~~~~~~~ [forbidden]
+            return someParam;
+          }
         }
       `,
     ),

--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -44,12 +44,6 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
       new Foo(() => 42, 0);
       new Foo;
     `,
-    stripIndent`
-      // couldReturnType is bugged for block body implicit return types (#57)
-      import { of } from "rxjs";
-
-      [1, 2, 3].forEach(i => { return of(i); });
-    `,
     // #endregion valid; void return argument
     // #region valid; void return attribute
     {
@@ -298,6 +292,15 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
 
         [1, 2, 3].forEach(i => of(i));
                           ~~~~~~~~~~ [forbiddenVoidReturnArgument]
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return argument; block body; implicit return type
+        import { of } from "rxjs";
+
+        [1, 2, 3].forEach(i => { return of(i); });
+                          ~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnArgument]
       `,
     ),
     fromFixture(


### PR DESCRIPTION
Fixes `finnish`, `no-finnish`, and `no-misused-observables` failing to check functions with implicit return types.

Resolves #57 