### PR TITLE
chore: stop publishing docs to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist",
-    "docs"
+    "dist"
   ],
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
The upstream repo will publish the `docs` folder to npm when published.  But most ESLint plugins nowadays do not do this.  We can gain some space savings by removing `docs` from the published artifacts.

Output from `npm pack` before removing `docs`:

```txt
npm notice package size: 62.7 kB
npm notice unpacked size: 378.7 kB
```

After removing `docs`:

```txt
npm notice package size: 48.4 kB
npm notice unpacked size: 298.8 kB
```