### PR TITLE
docs: use relative source paths

### DIFF
--- a/docs/rules/ban-observables.md
+++ b/docs/rules/ban-observables.md
@@ -38,5 +38,5 @@ If you have no need to ban importing anything from `rxjs`, you don't need this r
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/ban-observables.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/ban-observables.test.ts)
+- [Rule source](/src/rules/ban-observables.ts)
+- [Test source](/tests/rules/ban-observables.test.ts)

--- a/docs/rules/ban-operators.md
+++ b/docs/rules/ban-operators.md
@@ -40,5 +40,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/ban-operators.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/ban-operators.test.ts)
+- [Rule source](/src/rules/ban-operators.ts)
+- [Test source](/tests/rules/ban-operators.test.ts)

--- a/docs/rules/finnish.md
+++ b/docs/rules/finnish.md
@@ -87,5 +87,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/finnish.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/finnish.test.ts)
+- [Rule source](/src/rules/finnish.ts)
+- [Test source](/tests/rules/finnish.test.ts)

--- a/docs/rules/just.md
+++ b/docs/rules/just.md
@@ -16,5 +16,5 @@ If you prefer `of` in your project, you will want to avoid this rule.
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/just.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/just.test.ts)
+- [Rule source](/src/rules/just.ts)
+- [Test source](/tests/rules/just.test.ts)

--- a/docs/rules/no-async-subscribe.md
+++ b/docs/rules/no-async-subscribe.md
@@ -50,5 +50,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-async-subscribe.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-async-subscribe.test.ts)
+- [Rule source](/src/rules/no-async-subscribe.ts)
+- [Test source](/tests/rules/no-async-subscribe.test.ts)

--- a/docs/rules/no-connectable.md
+++ b/docs/rules/no-connectable.md
@@ -29,5 +29,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-connectable.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-connectable.test.ts)
+- [Rule source](/src/rules/no-connectable.ts)
+- [Test source](/tests/rules/no-connectable.test.ts)

--- a/docs/rules/no-create.md
+++ b/docs/rules/no-create.md
@@ -39,5 +39,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-create.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-create.test.ts)
+- [Rule source](/src/rules/no-create.ts)
+- [Test source](/tests/rules/no-create.test.ts)

--- a/docs/rules/no-cyclic-action.md
+++ b/docs/rules/no-cyclic-action.md
@@ -84,5 +84,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-cyclic-action.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-cyclic-action.test.ts)
+- [Rule source](/src/rules/no-cyclic-action.ts)
+- [Test source](/tests/rules/no-cyclic-action.test.ts)

--- a/docs/rules/no-explicit-generics.md
+++ b/docs/rules/no-explicit-generics.md
@@ -28,5 +28,5 @@ This rule has known problems in the latest release:
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-explicit-generics.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-explicit-generics.test.ts)
+- [Rule source](/src/rules/no-explicit-generics.ts)
+- [Test source](/tests/rules/no-explicit-generics.test.ts)

--- a/docs/rules/no-exposed-subjects.md
+++ b/docs/rules/no-exposed-subjects.md
@@ -64,5 +64,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-exposed-subjects.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-exposed-subjects.test.ts)
+- [Rule source](/src/rules/no-exposed-subjects.ts)
+- [Test source](/tests/rules/no-exposed-subjects.test.ts)

--- a/docs/rules/no-finnish.md
+++ b/docs/rules/no-finnish.md
@@ -38,5 +38,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-finnish.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-finnish.test.ts)
+- [Rule source](/src/rules/no-finnish.ts)
+- [Test source](/tests/rules/no-finnish.test.ts)

--- a/docs/rules/no-floating-observables.md
+++ b/docs/rules/no-floating-observables.md
@@ -64,5 +64,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-floating-observables.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-floating-observables.test.ts)
+- [Rule source](/src/rules/no-floating-observables.ts)
+- [Test source](/tests/rules/no-floating-observables.test.ts)

--- a/docs/rules/no-ignored-default-value.md
+++ b/docs/rules/no-ignored-default-value.md
@@ -39,5 +39,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-ignored-default-value.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-ignored-default-value.test.ts)
+- [Rule source](/src/rules/no-ignored-default-value.ts)
+- [Test source](/tests/rules/no-ignored-default-value.test.ts)

--- a/docs/rules/no-ignored-error.md
+++ b/docs/rules/no-ignored-error.md
@@ -49,5 +49,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-ignored-error.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-ignored-error.test.ts)
+- [Rule source](/src/rules/no-ignored-error.ts)
+- [Test source](/tests/rules/no-ignored-error.test.ts)

--- a/docs/rules/no-ignored-notifier.md
+++ b/docs/rules/no-ignored-notifier.md
@@ -43,5 +43,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-ignored-notifier.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-ignored-notifier.test.ts)
+- [Rule source](/src/rules/no-ignored-notifier.ts)
+- [Test source](/tests/rules/no-ignored-notifier.test.ts)

--- a/docs/rules/no-ignored-replay-buffer.md
+++ b/docs/rules/no-ignored-replay-buffer.md
@@ -43,5 +43,5 @@ If you don't care about implicitly defaulting to `Infinity` in your replay buffe
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-ignored-replay-buffer.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-ignored-replay-buffer.test.ts)
+- [Rule source](/src/rules/no-ignored-replay-buffer.ts)
+- [Test source](/tests/rules/no-ignored-replay-buffer.test.ts)

--- a/docs/rules/no-ignored-subscribe.md
+++ b/docs/rules/no-ignored-subscribe.md
@@ -42,5 +42,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-ignored-subscribe.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-ignored-subscribe.test.ts)
+- [Rule source](/src/rules/no-ignored-subscribe.ts)
+- [Test source](/tests/rules/no-ignored-subscribe.test.ts)

--- a/docs/rules/no-ignored-subscription.md
+++ b/docs/rules/no-ignored-subscription.md
@@ -42,5 +42,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-ignored-subscription.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-ignored-subscription.test.ts)
+- [Rule source](/src/rules/no-ignored-subscription.ts)
+- [Test source](/tests/rules/no-ignored-subscription.test.ts)

--- a/docs/rules/no-ignored-takewhile-value.md
+++ b/docs/rules/no-ignored-takewhile-value.md
@@ -31,5 +31,5 @@ If you don't care about using the given value in a `takeWhile` callback, then yo
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-ignored-takewhile-value.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-ignored-takewhile-value.test.ts)
+- [Rule source](/src/rules/no-ignored-takewhile-value.ts)
+- [Test source](/tests/rules/no-ignored-takewhile-value.test.ts)

--- a/docs/rules/no-implicit-any-catch.md
+++ b/docs/rules/no-implicit-any-catch.md
@@ -105,5 +105,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-implicit-any-catch.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-implicit-any-catch.test.ts)
+- [Rule source](/src/rules/no-implicit-any-catch.ts)
+- [Test source](/tests/rules/no-implicit-any-catch.test.ts)

--- a/docs/rules/no-index.md
+++ b/docs/rules/no-index.md
@@ -30,5 +30,5 @@ If you don't care about unnecessary import path segments, then you don't need th
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-index.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-index.test.ts)
+- [Rule source](/src/rules/no-index.ts)
+- [Test source](/tests/rules/no-index.test.ts)

--- a/docs/rules/no-internal.md
+++ b/docs/rules/no-internal.md
@@ -34,5 +34,5 @@ However, keep in mind that internal modules may change without notice.
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-internal.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-internal.test.ts)
+- [Rule source](/src/rules/no-internal.ts)
+- [Test source](/tests/rules/no-internal.test.ts)

--- a/docs/rules/no-misused-observables.md
+++ b/docs/rules/no-misused-observables.md
@@ -97,5 +97,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-misused-observables.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-misused-observables.test.ts)
+- [Rule source](/src/rules/no-misused-observables.ts)
+- [Test source](/tests/rules/no-misused-observables.test.ts)

--- a/docs/rules/no-nested-subscribe.md
+++ b/docs/rules/no-nested-subscribe.md
@@ -42,5 +42,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-nested-subscribe.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-nested-subscribe.test.ts)
+- [Rule source](/src/rules/no-nested-subscribe.ts)
+- [Test source](/tests/rules/no-nested-subscribe.test.ts)

--- a/docs/rules/no-redundant-notify.md
+++ b/docs/rules/no-redundant-notify.md
@@ -46,5 +46,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-redundant-notify.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-redundant-notify.test.ts)
+- [Rule source](/src/rules/no-redundant-notify.ts)
+- [Test source](/tests/rules/no-redundant-notify.test.ts)

--- a/docs/rules/no-sharereplay.md
+++ b/docs/rules/no-sharereplay.md
@@ -45,5 +45,5 @@ potentially leading to unexpected behavior and memory leaks.
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-sharereplay.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-sharereplay.test.ts)
+- [Rule source](/src/rules/no-sharereplay.ts)
+- [Test source](/tests/rules/no-sharereplay.test.ts)

--- a/docs/rules/no-subclass.md
+++ b/docs/rules/no-subclass.md
@@ -19,5 +19,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-subclass.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-subclass.test.ts)
+- [Rule source](/src/rules/no-subclass.ts)
+- [Test source](/tests/rules/no-subclass.test.ts)

--- a/docs/rules/no-subject-unsubscribe.md
+++ b/docs/rules/no-subject-unsubscribe.md
@@ -59,5 +59,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-subject-unsubscribe.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-subject-unsubscribe.test.ts)
+- [Rule source](/src/rules/no-subject-unsubscribe.ts)
+- [Test source](/tests/rules/no-subject-unsubscribe.test.ts)

--- a/docs/rules/no-subject-value.md
+++ b/docs/rules/no-subject-value.md
@@ -15,5 +15,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-subject-value.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-subject-value.test.ts)
+- [Rule source](/src/rules/no-subject-value.ts)
+- [Test source](/tests/rules/no-subject-value.test.ts)

--- a/docs/rules/no-subscribe-handlers.md
+++ b/docs/rules/no-subscribe-handlers.md
@@ -49,5 +49,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-subscribe-handlers.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-subscribe-handlers.test.ts)
+- [Rule source](/src/rules/no-subscribe-handlers.ts)
+- [Test source](/tests/rules/no-subscribe-handlers.test.ts)

--- a/docs/rules/no-subscribe-in-pipe.md
+++ b/docs/rules/no-subscribe-in-pipe.md
@@ -51,5 +51,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-subscribe-in-pipe.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-subscribe-in-pipe.test.ts)
+- [Rule source](/src/rules/no-subscribe-in-pipe.ts)
+- [Test source](/tests/rules/no-subscribe-in-pipe.test.ts)

--- a/docs/rules/no-topromise.md
+++ b/docs/rules/no-topromise.md
@@ -33,5 +33,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-topromise.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-topromise.test.ts)
+- [Rule source](/src/rules/no-topromise.ts)
+- [Test source](/tests/rules/no-topromise.test.ts)

--- a/docs/rules/no-unbound-methods.md
+++ b/docs/rules/no-unbound-methods.md
@@ -57,5 +57,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-unbound-methods.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-unbound-methods.test.ts)
+- [Rule source](/src/rules/no-unbound-methods.ts)
+- [Test source](/tests/rules/no-unbound-methods.test.ts)

--- a/docs/rules/no-unsafe-catch.md
+++ b/docs/rules/no-unsafe-catch.md
@@ -70,5 +70,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-unsafe-catch.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-unsafe-catch.test.ts)
+- [Rule source](/src/rules/no-unsafe-catch.ts)
+- [Test source](/tests/rules/no-unsafe-catch.test.ts)

--- a/docs/rules/no-unsafe-first.md
+++ b/docs/rules/no-unsafe-first.md
@@ -36,5 +36,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-unsafe-first.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-unsafe-first.test.ts)
+- [Rule source](/src/rules/no-unsafe-first.ts)
+- [Test source](/tests/rules/no-unsafe-first.test.ts)

--- a/docs/rules/no-unsafe-subject-next.md
+++ b/docs/rules/no-unsafe-subject-next.md
@@ -42,5 +42,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-unsafe-subject-next.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-unsafe-subject-next.test.ts)
+- [Rule source](/src/rules/no-unsafe-subject-next.ts)
+- [Test source](/tests/rules/no-unsafe-subject-next.test.ts)

--- a/docs/rules/no-unsafe-switchmap.md
+++ b/docs/rules/no-unsafe-switchmap.md
@@ -60,5 +60,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-unsafe-switchmap.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-unsafe-switchmap.test.ts)
+- [Rule source](/src/rules/no-unsafe-switchmap.ts)
+- [Test source](/tests/rules/no-unsafe-switchmap.test.ts)

--- a/docs/rules/no-unsafe-takeuntil.md
+++ b/docs/rules/no-unsafe-takeuntil.md
@@ -68,5 +68,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/no-unsafe-takeuntil.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/no-unsafe-takeuntil.test.ts)
+- [Rule source](/src/rules/no-unsafe-takeuntil.ts)
+- [Test source](/tests/rules/no-unsafe-takeuntil.test.ts)

--- a/docs/rules/prefer-observer.md
+++ b/docs/rules/prefer-observer.md
@@ -62,5 +62,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/prefer-observer.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/prefer-observer.test.ts)
+- [Rule source](/src/rules/prefer-observer.ts)
+- [Test source](/tests/rules/prefer-observer.test.ts)

--- a/docs/rules/prefer-root-operators.md
+++ b/docs/rules/prefer-root-operators.md
@@ -41,5 +41,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/prefer-root-operators.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/prefer-root-operators.test.ts)
+- [Rule source](/src/rules/prefer-root-operators.ts)
+- [Test source](/tests/rules/prefer-root-operators.test.ts)

--- a/docs/rules/suffix-subjects.md
+++ b/docs/rules/suffix-subjects.md
@@ -77,5 +77,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/suffix-subjects.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/suffix-subjects.test.ts)
+- [Rule source](/src/rules/suffix-subjects.ts)
+- [Test source](/tests/rules/suffix-subjects.test.ts)

--- a/docs/rules/throw-error.md
+++ b/docs/rules/throw-error.md
@@ -49,5 +49,5 @@ Type checked lint rules are more powerful than traditional lint rules, but also 
 
 ## Resources
 
-- [Rule source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/src/rules/throw-error.ts)
-- [Test source](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/blob/main/tests/rules/throw-error.test.ts)
+- [Rule source](/src/rules/throw-error.ts)
+- [Test source](/tests/rules/throw-error.test.ts)


### PR DESCRIPTION
We can get away without putting the full "Rule source" and "Test source" URL and just use relative links.