### PR TITLE
Fix #77 - Allow explicit union types on `no-explicit-generics` rule

### DIFF
--- a/docs/rules/no-explicit-generics.md
+++ b/docs/rules/no-explicit-generics.md
@@ -10,7 +10,7 @@ Examples of **incorrect** code for this rule:
 
 ```ts
 import { BehaviorSubject } from "rxjs";
-const subject = new BehaviorSubject<number>(42);
+const subject = new BehaviorSubject<number>(42); //Adding a type here is not useful
 ```
 
 Examples of **correct** code for this rule:
@@ -20,11 +20,10 @@ import { BehaviorSubject } from "rxjs";
 const subject = new BehaviorSubject(42);
 ```
 
-## When Not To Use It
-
-This rule has known problems in the latest release:
-
-- ([#77](https://github.com/JasonWeinzierl/eslint-plugin-rxjs-x/issues/77)) Type unions cause false positives e.g. `new BehaviorSubject<number | null>(null)` will be incorrectly caught by this rule.
+```ts
+import { BehaviorSubject } from "rxjs";
+const subject = new BehaviorSubject<ISomeType | null>(null); //Allow union types to be defined, useful when things can be nullable
+```
 
 ## Resources
 

--- a/src/etc/is.ts
+++ b/src/etc/is.ts
@@ -144,8 +144,8 @@ export function isUnaryExpression(node: TSESTree.Node): node is TSESTree.UnaryEx
   return node.type === AST_NODE_TYPES.UnaryExpression;
 }
 
-export function isUnionType(node?: TSESTree.Node): node is TSESTree.TSUnionType {
-  return node === undefined ? false : node.type === AST_NODE_TYPES.TSUnionType;
+export function isUnionType(node: TSESTree.Node): node is TSESTree.TSUnionType {
+  return node.type === AST_NODE_TYPES.TSUnionType;
 }
 
 export function isVariableDeclarator(

--- a/src/etc/is.ts
+++ b/src/etc/is.ts
@@ -144,6 +144,10 @@ export function isUnaryExpression(node: TSESTree.Node): node is TSESTree.UnaryEx
   return node.type === AST_NODE_TYPES.UnaryExpression;
 }
 
+export function isUnionType(node?: TSESTree.Node): node is TSESTree.TSUnionType {
+  return node === undefined ? false : node.type === AST_NODE_TYPES.TSUnionType;
+}
+
 export function isVariableDeclarator(
   node: TSESTree.Node,
 ): node is TSESTree.VariableDeclarator {

--- a/src/rules/no-explicit-generics.ts
+++ b/src/rules/no-explicit-generics.ts
@@ -30,7 +30,7 @@ export const noExplicitGenericsRule = ruleCreator({
       } = parent;
 
       const typeArgs = parent.typeArguments?.params[0];
-      if (isArrayExpression(value) || isObjectExpression(value) || isUnionType(typeArgs)) {
+      if (isArrayExpression(value) || isObjectExpression(value) || (typeArgs && isUnionType(typeArgs))) {
         return;
       }
       report(node);
@@ -43,7 +43,7 @@ export const noExplicitGenericsRule = ruleCreator({
       } = parent;
 
       const typeArgs = parent.typeArguments?.params[0];
-      if (isArrayExpression(value) || isObjectExpression(value) || isUnionType(typeArgs)) {
+      if (isArrayExpression(value) || isObjectExpression(value) || (typeArgs && isUnionType(typeArgs))) {
         return;
       }
       report(node);

--- a/src/rules/no-explicit-generics.ts
+++ b/src/rules/no-explicit-generics.ts
@@ -1,5 +1,5 @@
 import { TSESTree as es } from '@typescript-eslint/utils';
-import { isArrayExpression, isObjectExpression } from '../etc';
+import { isArrayExpression, isObjectExpression, isUnionType } from '../etc';
 import { ruleCreator } from '../utils';
 
 export const noExplicitGenericsRule = ruleCreator({
@@ -28,7 +28,9 @@ export const noExplicitGenericsRule = ruleCreator({
       const {
         arguments: [value],
       } = parent;
-      if (isArrayExpression(value) || isObjectExpression(value)) {
+
+      const typeArgs = parent.typeArguments?.params[0];
+      if (isArrayExpression(value) || isObjectExpression(value) || isUnionType(typeArgs)) {
         return;
       }
       report(node);
@@ -39,7 +41,9 @@ export const noExplicitGenericsRule = ruleCreator({
       const {
         arguments: [, value],
       } = parent;
-      if (isArrayExpression(value) || isObjectExpression(value)) {
+
+      const typeArgs = parent.typeArguments?.params[0];
+      if (isArrayExpression(value) || isObjectExpression(value) || isUnionType(typeArgs)) {
         return;
       }
       report(node);

--- a/tests/rules/no-explicit-generics.test.ts
+++ b/tests/rules/no-explicit-generics.test.ts
@@ -38,6 +38,22 @@ ruleTester({ types: false }).run('no-explicit-generics', noExplicitGenericsRule,
         const h = new Notification<{ answer?: number }>("N", {});
       `,
     },
+    {
+      code: stripIndent`
+        // with union types
+        import { BehaviorSubject, Notification } from "rxjs";
+        const a = new BehaviorSubject<number | null>(null);
+        const b = new BehaviorSubject<number | null>(42);
+        const c = new BehaviorSubject<{ answer: number } | null>({ answer: 42 });
+        const d = new BehaviorSubject<{ answer: number } | null>(null);
+        const e = new BehaviorSubject<{ answer?: number }>({});
+        const f = new Notification<number | null>("N", 42);
+        const g = new Notification<number | null>("N", null);
+        const h = new Notification<{ answer: number } | null>("N", { answer: 42 });
+        const i = new Notification<{ answer?: number } | null>("N", {});
+        const j = new Notification<{ answer?: number } | null>("N", null);
+      `,
+    },
   ],
   invalid: [
     fromFixture(


### PR DESCRIPTION
Now something like the following will be allowed:
```ts
const subject = new BehaviorSubject<ISomeType | null>(null);
```

This addresses #77 