### PR TITLE
feat(no-unbound-methods): allow unbound signals

### DIFF
--- a/docs/rules/no-unbound-methods.md
+++ b/docs/rules/no-unbound-methods.md
@@ -8,6 +8,9 @@
 
 This rule effects failures if unbound methods are passed as callbacks.
 
+This rule is aware of Angular's `Signal` type by default
+which can be safely passed unbound.
+
 ## Rule details
 
 Examples of **incorrect** code for this rule:
@@ -40,6 +43,16 @@ return this.http
     catchError(this.handleError.bind(this))
   );
 ```
+
+## Options
+
+<!-- begin auto-generated rule options list -->
+
+| Name         | Description                                                       | Type     | Default    |
+| :----------- | :---------------------------------------------------------------- | :------- | :--------- |
+| `allowTypes` | An array of function types that are allowed to be passed unbound. | String[] | [`Signal`] |
+
+<!-- end auto-generated rule options list -->
 
 ## When Not To Use It
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,13 @@ export const SOURCES_OBJECT_ACCEPTING_STATIC_OBSERVABLE_CREATORS = [
 ];
 
 /**
+ * The names of types that are allowed to be passed unbound.
+ */
+export const DEFAULT_UNBOUND_ALLOWED_TYPES = [
+  'Signal',
+];
+
+/**
  * The names of operators that are safe to be used after
  * operators like `takeUntil` that complete the observable.
  */


### PR DESCRIPTION
Adds a new option `allowTypes` to the rule `no-unbound-methods` so users may specify specific types that are safe to pass unbound.

By default, we set it to `Signal` to support Angular's signals out of the box.

Resolves #209 and upstream https://github.com/cartant/eslint-plugin-rxjs/issues/137