### PR TITLE
Don't require Finnish notation or Subject suffixes for `forkJoin` or `combineLatest` properties

### DIFF
--- a/src/etc/is.ts
+++ b/src/etc/is.ts
@@ -149,3 +149,11 @@ export function isVariableDeclarator(
 ): node is TSESTree.VariableDeclarator {
   return node.type === AST_NODE_TYPES.VariableDeclarator;
 }
+
+export function isCallingMethodWhitelistedFromNamingRules(expression: TSESTree.Node): boolean {
+  const whitelistedMethods = ['combineLatest', 'forkJoin'];
+  if (isCallExpression(expression) && isIdentifier(expression.callee)) {
+    return whitelistedMethods.includes(expression.callee.name);
+  }
+  return false;
+}

--- a/src/rules/finnish.ts
+++ b/src/rules/finnish.ts
@@ -2,7 +2,8 @@ import { AST_NODE_TYPES, TSESTree as es, ESLintUtils } from '@typescript-eslint/
 import {
   findParent,
   getLoc,
-  getTypeServices } from '../etc';
+  getTypeServices,
+  isCallingMethodWhitelistedFromNamingRules } from '../etc';
 import { ruleCreator } from '../utils';
 
 const defaultOptions: readonly {
@@ -228,7 +229,7 @@ export const finnishRule = ruleCreator({
       ) => {
         if (validate.properties) {
           const parent = node.parent as es.Property;
-          if (node === parent.key) {
+          if (node === parent.key && !isCallingMethodWhitelistedFromNamingRules(parent.parent.parent)) {
             checkNode(node);
           }
         }

--- a/src/rules/suffix-subjects.ts
+++ b/src/rules/suffix-subjects.ts
@@ -3,6 +3,7 @@ import {
   findParent,
   getLoc,
   getTypeServices,
+  isCallingMethodWhitelistedFromNamingRules,
 } from '../etc';
 import { escapeRegExp, ruleCreator } from '../utils';
 
@@ -161,7 +162,7 @@ export const suffixSubjectsRule = ruleCreator({
       ) => {
         if (validate.properties) {
           const parent = node.parent as es.Property;
-          if (node === parent.key) {
+          if (node === parent.key && !isCallingMethodWhitelistedFromNamingRules(parent.parent.parent)) {
             checkNode(node);
           }
         }

--- a/tests/rules/finnish.test.ts
+++ b/tests/rules/finnish.test.ts
@@ -200,6 +200,15 @@ ruleTester({ types: true }).run('finnish', finnishRule, {
       `,
       options: [{ properties: false }],
     },
+    {
+      code: stripIndent`
+        // RxJS methods that takes observables should have whitelisted object property names
+        import { of, combineLatest, forkJoin } from "rxjs";
+
+        combineLatest({ one: of(0), two: of('a') });
+        forkJoin({ one: of(0), two: of('a') });
+      `,
+    },
   ],
   invalid: [
     fromFixture(

--- a/tests/rules/suffix-subjects.test.ts
+++ b/tests/rules/suffix-subjects.test.ts
@@ -282,6 +282,15 @@ ruleTester({ types: true }).run('suffix-subjects', suffixSubjectsRule, {
         const mySubject = new MySubject<number>();
       `,
     },
+    {
+      code: stripIndent`
+        // RxJS methods that takes subjects should have whitelisted object property names
+        import { Subject, BehaviorSubject, combineLatest, forkJoin } from "rxjs";
+
+        combineLatest({ one: new Subject<number>(), two: new BehaviorSubject('a') });
+        forkJoin({ one: new Subject<number>(), two: new BehaviorSubject('a') });
+      `,
+    },
   ],
   invalid: [
     fromFixture(


### PR DESCRIPTION
This addresses #40 _(as well as a personal annoyance for me!)_

### Before
```ts
combineLatest({
  number$: of(0),
  letterSubject$: new BehaviorSubject('a')
});
```

### After 
```ts
combineLatest({
  number: of(0),
  letter: new BehaviorSubject('a')
});
```

----

I am not sure if I did this in the best way possible or if this catches any/all edge cases. Please let me know if this can be improved somehow