### PR TITLE
fix(no-async-subscribe): report async next properties on observer object

### DIFF
--- a/docs/rules/no-async-subscribe.md
+++ b/docs/rules/no-async-subscribe.md
@@ -23,6 +23,14 @@ of(42).subscribe(async value => {
     const data2 = await fetch(`https://api.some.com/things/${data1.id}`);
     console.log(data2);
 });
+
+of(42).subscribe({
+    next: async () => {
+        const data1 = await fetch(`https://api.some.com/things/${value}`);
+        const data2 = await fetch(`https://api.some.com/things/${data1.id}`);
+        console.log(data2);
+    },
+})
 ```
 
 Examples of **correct** code for this rule:
@@ -34,6 +42,11 @@ of(42).pipe(
     switchMap(value => fetch(`http://api.some.com/things/${value}`)),
     switchMap(data1 => fetch(`http://api.some.com/things/${data1.id}`)),
 ).subscribe(data2 => console.log(data2));
+
+of(42).pipe(
+    switchMap(value => fetch(`http://api.some.com/things/${value}`)),
+    switchMap(data1 => fetch(`http://api.some.com/things/${data1.id}`)),
+).subscribe({ next: data2 => console.log(data2) });
 ```
 
 ## When Not To Use It

--- a/src/rules/no-async-subscribe.ts
+++ b/src/rules/no-async-subscribe.ts
@@ -11,7 +11,7 @@ export const noAsyncSubscribeRule = ruleCreator({
       requiresTypeChecking: true,
     },
     messages: {
-      forbidden: 'Passing async functions to subscribe is forbidden.',
+      forbidden: 'Passing async functions to subscribe is forbidden. Use operators like `concatMap` or `switchMap` to avoid race conditions.',
     },
     schema: [],
     type: 'problem',

--- a/src/rules/no-async-subscribe.ts
+++ b/src/rules/no-async-subscribe.ts
@@ -1,5 +1,5 @@
 import { TSESTree as es } from '@typescript-eslint/utils';
-import { getTypeServices } from '../etc';
+import { getTypeServices, isArrowFunctionExpression, isFunctionExpression } from '../etc';
 import { ruleCreator } from '../utils';
 
 export const noAsyncSubscribeRule = ruleCreator({
@@ -20,34 +20,59 @@ export const noAsyncSubscribeRule = ruleCreator({
   create: (context) => {
     const { couldBeObservable } = getTypeServices(context);
 
-    function checkNode(
+    function report(
       node: es.FunctionExpression | es.ArrowFunctionExpression,
     ) {
-      const parentNode = node.parent as es.CallExpression;
+      const { loc } = node;
+      // only report the `async` keyword
+      const asyncLoc = {
+        ...loc,
+        end: {
+          ...loc.start,
+          column: loc.start.column + 5,
+        },
+      };
+
+      context.report({
+        messageId: 'forbidden',
+        loc: asyncLoc,
+      });
+    }
+
+    function checkSingleNext(
+      funcNode: es.FunctionExpression | es.ArrowFunctionExpression,
+    ) {
+      const parentNode = funcNode.parent as es.CallExpression;
       const callee = parentNode.callee as es.MemberExpression;
 
       if (couldBeObservable(callee.object)) {
-        const { loc } = node;
-        // only report the `async` keyword
-        const asyncLoc = {
-          ...loc,
-          end: {
-            ...loc.start,
-            column: loc.start.column + 5,
-          },
-        };
-
-        context.report({
-          messageId: 'forbidden',
-          loc: asyncLoc,
-        });
+        report(funcNode);
       }
     }
+
+    function checkObserverObjectProp(
+      propNode: es.Property,
+    ) {
+      const parentNode = propNode.parent.parent as es.CallExpression;
+      const callee = parentNode.callee as es.MemberExpression;
+
+      if (couldBeObservable(callee.object)
+        && (isArrowFunctionExpression(propNode.value)
+          || isFunctionExpression(propNode.value))
+      ) {
+        report(propNode.value);
+      }
+    }
+
     return {
       'CallExpression[callee.property.name=\'subscribe\'] > FunctionExpression[async=true]':
-        checkNode,
+        checkSingleNext,
       'CallExpression[callee.property.name=\'subscribe\'] > ArrowFunctionExpression[async=true]':
-        checkNode,
+        checkSingleNext,
+      'CallExpression[callee.property.name=\'subscribe\'] > ObjectExpression > Property[key.name=\'next\'][value.type="ArrowFunctionExpression"][value.async=true]':
+        checkObserverObjectProp,
+      'CallExpression[callee.property.name=\'subscribe\'] > ObjectExpression > Property[key.name=\'next\'][value.type="FunctionExpression"][value.async=true]':
+        checkObserverObjectProp,
     };
   },
 });

--- a/tests/rules/no-async-subscribe.test.ts
+++ b/tests/rules/no-async-subscribe.test.ts
@@ -33,6 +33,31 @@ ruleTester({ types: true }).run('no-async-subscribe', noAsyncSubscribeRule, {
       };
       whatever.subscribe(async () => { await 42; });
     `,
+    stripIndent`
+      // observer object
+      import { of } from "rxjs";
+
+      of('a').subscribe({
+        next: () => {},
+      });
+      of('a').subscribe({
+        next: function() {},
+      });
+    `,
+    stripIndent`
+      // non-RxJS observer object
+      const whatever = {
+        subscribe: (observer: {
+          next?: (value: unknown) => void;
+        }) => {},
+      };
+      whatever.subscribe({
+        next: () => {},
+      });
+      whatever.subscribe({
+        next: function() {},
+      });
+    `,
   ],
   invalid: [
     fromFixture(
@@ -48,12 +73,38 @@ ruleTester({ types: true }).run('no-async-subscribe', noAsyncSubscribeRule, {
     ),
     fromFixture(
       stripIndent`
+        // async arrow function; observer object
+        import { of } from "rxjs";
+
+        of("a").subscribe({
+          next: async () => {
+                ~~~~~ [forbidden]
+            return await "a";
+          },
+        });
+      `,
+    ),
+    fromFixture(
+      stripIndent`
         // async function
         import { of } from "rxjs";
 
         of("a").subscribe(async function() {
                           ~~~~~ [forbidden]
           return await "a";
+        });
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // async function; observer object
+        import { of } from "rxjs";
+
+        of("a").subscribe({
+          next: async function() {
+                ~~~~~ [forbidden]
+            return await "a";
+          },
         });
       `,
     ),


### PR DESCRIPTION
Adds support for catching `next: async () => ...` properties when passing an object into `subscribe`.

This may cause a significant increase in reports for this rule, because previously we were not checking observer objects at all and `prefer-observer` may have been pushing codebases to migrate to observer objects.  So this also enhances the `forbidden` message to include a snippet from this rule's docs, so that intellisense is more useful.

Resolves #163 