### PR TITLE
fix(no-implicit-any-catch): proper parenthesis for two-param catchError

### DIFF
--- a/src/rules/no-implicit-any-catch.ts
+++ b/src/rules/no-implicit-any-catch.ts
@@ -84,7 +84,7 @@ export const noImplicitAnyCatchRule = ruleCreator({
         isArrowFunctionExpression(callback)
         || isFunctionExpression(callback)
       ) {
-        const [param] = callback.params;
+        const [param, ...restParams] = callback.params;
         if (!param) {
           return;
         }
@@ -128,7 +128,7 @@ export const noImplicitAnyCatchRule = ruleCreator({
           }
         } else {
           function fix(fixer: eslint.RuleFixer) {
-            if (isParenthesised(sourceCode, param)) {
+            if (isParenthesised(sourceCode, param) || restParams.length > 0) {
               return fixer.insertTextAfter(param, ': unknown');
             }
             return [

--- a/tests/rules/no-implicit-any-catch.test.ts
+++ b/tests/rules/no-implicit-any-catch.test.ts
@@ -97,6 +97,26 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
     },
     {
       code: stripIndent`
+        // arrow; explicit unknown and caught; default option
+        import { throwError, catchError, Observable } from "rxjs";
+
+        throwError(new Error("Kaboom!")).pipe(
+          catchError((error: unknown, caught: Observable<unknown>) => console.error(error)),
+        );
+      `,
+    },
+    {
+      code: stripIndent`
+        // non-arrow; explicit unknown and caught; default option
+        import { throwError, catchError, Observable } from "rxjs";
+
+        throwError(new Error("Kaboom!")).pipe(
+          catchError(function (error: unknown, caught: Observable<unknown>) { console.error(error); }),
+        );
+      `,
+    },
+    {
+      code: stripIndent`
         // subscribe; arrow; explicit unknown; default option
         import { throwError } from "rxjs";
 
@@ -119,6 +139,28 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
     },
     {
       code: stripIndent`
+        // subscribe; arrow; explicit unknown and caught; default option
+        import { throwError, catchError, Observable } from "rxjs";
+
+        throwError(new Error("Kaboom!")).subscribe(
+          undefined,
+          (error: unknown, caught: Observable<unknown>) => console.error(error)
+        );
+      `,
+    },
+    {
+      code: stripIndent`
+        // subscribe; arrow; explicit any and caught; default option
+        import { throwError, catchError, Observable } from "rxjs";
+
+        throwError(new Error("Kaboom!")).subscribe(
+          undefined,
+          (error: any, caught: Observable<unknown>) => console.error(error)
+        );
+      `,
+    },
+    {
+      code: stripIndent`
         // subscribe observer; arrow; explicit unknown; default option
         import { throwError } from "rxjs";
 
@@ -134,6 +176,26 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
 
         throwError("Kaboom!").subscribe({
           error: (error: any) => console.error(error)
+        });
+      `,
+    },
+    {
+      code: stripIndent`
+        // subscribe observer; arrow; explicit unknown and caught; default option
+        import { throwError, catchError, Observable } from "rxjs";
+
+        throwError(new Error("Kaboom!")).subscribe({
+          error: (error: unknown, caught: Observable<unknown>) => console.error(error)
+        });
+      `,
+    },
+    {
+      code: stripIndent`
+        // subscribe observer; arrow; explicit any and caught; default option
+        import { throwError, catchError, Observable } from "rxjs";
+
+        throwError(new Error("Kaboom!")).subscribe({
+          error: (error: any, caught: Observable<unknown>) => console.error(error)
         });
       `,
     },
@@ -274,6 +336,40 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
     ),
     fromFixture(
       stripIndent`
+        // arrow; implicit any and caught
+        import { throwError, catchError } from "rxjs";
+
+        throwError(new Error("Kaboom!")).pipe(
+          catchError((error, caught) => console.error(error)),
+                      ~~~~~ [implicitAny suggest]
+        );
+      `,
+      {
+        output: stripIndent`
+          // arrow; implicit any and caught
+          import { throwError, catchError } from "rxjs";
+
+          throwError(new Error("Kaboom!")).pipe(
+            catchError((error: unknown, caught) => console.error(error)),
+          );
+        `,
+        suggestions: [
+          {
+            messageId: 'suggestExplicitUnknown',
+            output: stripIndent`
+              // arrow; implicit any and caught
+              import { throwError, catchError } from "rxjs";
+
+              throwError(new Error("Kaboom!")).pipe(
+                catchError((error: unknown, caught) => console.error(error)),
+              );
+            `,
+          },
+        ],
+      },
+    ),
+    fromFixture(
+      stripIndent`
         // non-arrow; implicit any
         import { throwError } from "rxjs";
         import { catchError } from "rxjs/operators";
@@ -303,6 +399,40 @@ ruleTester({ types: true }).run('no-implicit-any-catch', noImplicitAnyCatchRule,
 
               throwError("Kaboom!").pipe(
                 catchError(function (error: unknown) { console.error(error); })
+              );
+            `,
+          },
+        ],
+      },
+    ),
+    fromFixture(
+      stripIndent`
+        // non-arrow; implicit any and caught
+        import { throwError, catchError } from "rxjs";
+
+        throwError(new Error("Kaboom!")).pipe(
+          catchError(function (error, caught) { console.error(error); })
+                               ~~~~~ [implicitAny suggest]
+        );
+      `,
+      {
+        output: stripIndent`
+          // non-arrow; implicit any and caught
+          import { throwError, catchError } from "rxjs";
+
+          throwError(new Error("Kaboom!")).pipe(
+            catchError(function (error: unknown, caught) { console.error(error); })
+          );
+        `,
+        suggestions: [
+          {
+            messageId: 'suggestExplicitUnknown',
+            output: stripIndent`
+              // non-arrow; implicit any and caught
+              import { throwError, catchError } from "rxjs";
+
+              throwError(new Error("Kaboom!")).pipe(
+                catchError(function (error: unknown, caught) { console.error(error); })
               );
             `,
           },


### PR DESCRIPTION
We're assuming that if `callback` has more than one parameter (i.e. `restParams.length > 0`), then all the parameters should already be wrapped in parenthesis (or else it's invalid JS syntax), so we can safely insert `: unknown` and nothing else.

Resolves #224 