### PR TITLE
feat(no-misused-observables): improve report loc for methods

### DIFF
--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -740,7 +740,7 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
         type Foo = { bar: () => void };
         const foo: Foo = {
           bar: () => of(42),
-               ~~~~~~~~~~~~ [forbiddenVoidReturnProperty]
+                  ~~ [forbiddenVoidReturnProperty]
         };
       `,
     ),
@@ -752,7 +752,7 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
         type Foo = { bar: () => void };
         const foo: Foo = {
           bar(): Observable<number> { return of(42); },
-             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnProperty]
+                 ~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnProperty]
         };
       `,
     ),


### PR DESCRIPTION
See tseslint issue 10216.  If a property is a function, instead of reporting the entire function, report either its return type or else use `getFunctionHeadLocation` to report a more narrow location.  See tests for example.