### PR TITLE
fix(no-misused-observables): don't report on static accessor properties

### DIFF
--- a/src/etc/is.ts
+++ b/src/etc/is.ts
@@ -6,6 +6,12 @@ export function hasTypeAnnotation<T extends TSESTree.Node>(
   return 'typeAnnotation' in node && !!node.typeAnnotation;
 }
 
+export function isAccessorProperty(
+  node: TSESTree.Node,
+): node is TSESTree.AccessorProperty {
+  return node.type === AST_NODE_TYPES.AccessorProperty;
+}
+
 export function isArrayExpression(node: TSESTree.Node): node is TSESTree.ArrayExpression {
   return node.type === AST_NODE_TYPES.ArrayExpression;
 }

--- a/src/rules/no-misused-observables.ts
+++ b/src/rules/no-misused-observables.ts
@@ -4,6 +4,7 @@ import * as tsutils from 'ts-api-utils';
 import ts from 'typescript';
 import {
   getTypeServices,
+  isAccessorProperty,
   isArrowFunctionExpression,
   isFunctionDeclaration,
   isFunctionExpression,
@@ -443,8 +444,10 @@ function getMemberIfExists(
 }
 
 function isStaticMember(node: es.Node): boolean {
-  return (isMethodDefinition(node) || isPropertyDefinition(node))
-    && node.static;
+  return (isMethodDefinition(node)
+    || isPropertyDefinition(node)
+    || isAccessorProperty(node))
+  && node.static;
 }
 
 function getPropertyContextualType(

--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -137,6 +137,29 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
       }
     `,
     stripIndent`
+      // void return inherited method; static accessor properties
+      import { Observable, of } from "rxjs";
+
+      class Foo {
+        public foo = (): void => {};
+      }
+
+      class Bar extends Foo {
+        public static accessor foo = (): Observable<number> => of(42);
+      }
+    `,
+    stripIndent`
+      // void return inherited method; static accessor properties; unrelated
+
+      class Foo {
+        public foo = (): void => {};
+      }
+
+      class Bar extends Foo {
+        public static accessor foo = (): void => {};
+      }
+    `,
+    stripIndent`
       // void return inherited method; unrelated
       class Foo {
         foo(): void {}


### PR DESCRIPTION
See tseslint issue 10814.

Note that due to #66 , we currently wouldn't catch any violations of this rule for non-static accessors, but that should be fixed and tested separately in #66 .