### PR TITLE
feat: support plugin.meta.namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,11 @@ const allRules = {
 } satisfies TSESLint.FlatConfig.Plugin['rules'];
 
 const plugin = {
-  meta: { name, version },
+  meta: {
+    name,
+    version,
+    namespace: 'rxjs-x',
+  },
   /** Compatibility with `defineConfig` until https://github.com/typescript-eslint/typescript-eslint/issues/11543 is addressed. */
   rules: allRules as { [K in keyof typeof allRules]: (typeof allRules)[K] & Rule.RuleModule },
 } satisfies ESLint.Plugin;


### PR DESCRIPTION
ESLint recently added `plugin.meta.namespace` which allows users to remap a plugin's built-in namespace.  So with this change, you will now be able to override a shared configuration with your own namespace.

```js
import { defineConfig } from 'eslint/config';
import rxjsX from 'eslint-plugin-rxjs-x';

export default defineConfig(
  {
    plugins: {
      foo: rxjsX,
    },
    extends: ['foo/recommended'],
    rules: {
      'foo/no-async-subscribe': 'off',
    },
  },
);
```