### PR TITLE
fix: couldReturnType for finnish and no-misused-observables

### DIFF
--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -224,16 +224,6 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
       };
     `,
     stripIndent`
-      // couldReturnType is bugged for variables (#66)
-      import { Observable, of } from "rxjs";
-
-      type Foo = { bar: () => void };
-      const bar: () => Observable<number> = () => of(42);
-      const foo: Foo = {
-        bar,
-      };
-    `,
-    stripIndent`
       // void return property; union type
       import { Observable, of } from "rxjs";
 
@@ -771,8 +761,7 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Qux" }]
           doRxThing(): Observable<void>;
           syncMethodProperty: () => Observable<void>;
-          //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Qux" }]
-          // TODO(#66): couldReturnType doesn't work for properties.
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnInheritedMethod { "heritageTypeName": "Qux" }]
         }
       `,
     ),
@@ -799,6 +788,25 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
         const foo: Foo = {
           bar(): Observable<number> { return of(42); },
                  ~~~~~~~~~~~~~~~~~~ [forbiddenVoidReturnProperty]
+        };
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return property; object initializer with unions
+        import { Observable, of } from "rxjs";
+
+        type Foo = {
+          bar: () => void,
+          baz: () => void,
+        };
+        const bar = (() => of(42)) as (() => Observable<number>) | (() => string);
+        const baz: (() => Observable<number>) | (() => string) = () => of(42);
+        const foo: Foo = {
+          bar,
+          ~~~ [forbiddenVoidReturnProperty]
+          baz: baz,
+               ~~~ [forbiddenVoidReturnProperty]
         };
       `,
     ),


### PR DESCRIPTION
Overhauls a pre-existing utility `couldReturnType` that we brought over from `eslint-etc`.  Instead of trying to read the type annotations based on the node (which was spiraling into a complicated mess), we just use the type checker to loop over all the signature's return types.

This fixes the following:

* fix(finnish): false-positives from "strict" on variables, parameters, and properties
* fix(no-misused-observables): void return properties that are functions

Also:

* Alias TSESTree in get-type-services to match repository convention
* Fix unit test for Finnish missing dollar signs resulting in invalid TypeScript

Resolves #66 and cartant/eslint-plugin-rxjs#105