### PR TITLE
fix(no-misused-observables): expand property constituents

### DIFF
--- a/src/rules/no-misused-observables.ts
+++ b/src/rules/no-misused-observables.ts
@@ -480,7 +480,11 @@ function getPropertyContextualType(
     if (objType == null) {
       return;
     }
-    const propertySymbol = checker.getPropertyOfType(objType, tsNode.name.text);
+    const propertySymbol = tsutils
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- needed until we require ts-api-utils 2.1.0
+      .unionTypeParts(objType)
+      .map(t => checker.getPropertyOfType(t, tsNode.name.getText()))
+      .find(p => p);
     if (propertySymbol == null) {
       return;
     }

--- a/tests/rules/no-misused-observables.test.ts
+++ b/tests/rules/no-misused-observables.test.ts
@@ -793,7 +793,7 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
     ),
     fromFixture(
       stripIndent`
-        // void return property; object initializer with unions
+        // void return property; union variable
         import { Observable, of } from "rxjs";
 
         type Foo = {
@@ -807,6 +807,20 @@ ruleTester({ types: true }).run('no-misused-observables', noMisusedObservablesRu
           ~~~ [forbiddenVoidReturnProperty]
           baz: baz,
                ~~~ [forbiddenVoidReturnProperty]
+        };
+      `,
+    ),
+    fromFixture(
+      stripIndent`
+        // void return property; union signature
+        import { Observable, of } from "rxjs";
+
+        type Foo = {
+          bar: () => void,
+        } | undefined;
+        const foo: Foo = {
+          bar() { return of(42); },
+          ~~~ [forbiddenVoidReturnProperty]
         };
       `,
     ),


### PR DESCRIPTION
Catch improper void return property when the interface declares a property and the implementor implements it as a method.

`no-misused-observables` is based on `no-misused-promises`, so this is a backport of via https://github.com/typescript-eslint/typescript-eslint/pull/11706