### PR TITLE
refactor: require ts-api-utils 2.1, tseslint 8.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@typescript-eslint/scope-manager": "^8.19.1",
-    "@typescript-eslint/utils": "^8.19.1",
+    "@typescript-eslint/scope-manager": "^8.32.0",
+    "@typescript-eslint/utils": "^8.32.0",
     "common-tags": "^1.8.0",
     "decamelize": "^5.0.1",
-    "ts-api-utils": "^2.0.0",
+    "ts-api-utils": "^2.1.0",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/src/rules/no-misused-observables.ts
+++ b/src/rules/no-misused-observables.ts
@@ -391,8 +391,7 @@ function voidFunctionArguments(
   const voidReturnIndices = new Set<number>();
   const type = checker.getTypeAtLocation(tsNode.expression);
 
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- needed until we require ts-api-utils 2.1.0
-  for (const subType of tsutils.unionTypeParts(type)) {
+  for (const subType of tsutils.unionConstituents(type)) {
     const signatures = ts.isCallExpression(tsNode)
       ? subType.getCallSignatures()
       : subType.getConstructSignatures();
@@ -414,8 +413,7 @@ function isVoidReturningFunctionType(
 ): boolean {
   let hasVoidReturn = false;
 
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- needed until we require ts-api-utils 2.1.0
-  for (const subType of tsutils.unionTypeParts(type)) {
+  for (const subType of tsutils.unionConstituents(type)) {
     for (const signature of subType.getCallSignatures()) {
       const returnType = signature.getReturnType();
 
@@ -481,8 +479,7 @@ function getPropertyContextualType(
       return;
     }
     const propertySymbol = tsutils
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- needed until we require ts-api-utils 2.1.0
-      .unionTypeParts(objType)
+      .unionConstituents(objType)
       .map(t => checker.getPropertyOfType(t, tsNode.name.getText()))
       .find(p => p);
     if (propertySymbol == null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -901,7 +901,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.54.0, @typescript-eslint/scope-manager@npm:^8.19.1, @typescript-eslint/scope-manager@npm:^8.46.1":
+"@typescript-eslint/scope-manager@npm:8.54.0, @typescript-eslint/scope-manager@npm:^8.32.0, @typescript-eslint/scope-manager@npm:^8.46.1":
   version: 8.54.0
   resolution: "@typescript-eslint/scope-manager@npm:8.54.0"
   dependencies:
@@ -962,7 +962,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.54.0, @typescript-eslint/utils@npm:^8.0.0, @typescript-eslint/utils@npm:^8.19.1, @typescript-eslint/utils@npm:^8.46.1":
+"@typescript-eslint/utils@npm:8.54.0, @typescript-eslint/utils@npm:^8.0.0, @typescript-eslint/utils@npm:^8.32.0, @typescript-eslint/utils@npm:^8.46.1":
   version: 8.54.0
   resolution: "@typescript-eslint/utils@npm:8.54.0"
   dependencies:
@@ -2189,8 +2189,8 @@ __metadata:
     "@types/common-tags": "npm:^1.8.4"
     "@types/node": "npm:~18.18.0"
     "@typescript-eslint/rule-tester": "npm:^8.54.0"
-    "@typescript-eslint/scope-manager": "npm:^8.19.1"
-    "@typescript-eslint/utils": "npm:^8.19.1"
+    "@typescript-eslint/scope-manager": "npm:^8.32.0"
+    "@typescript-eslint/utils": "npm:^8.32.0"
     "@typescript/vfs": "npm:^1.6.2"
     "@vitest/coverage-v8": "npm:^3.2.4"
     "@vitest/eslint-plugin": "npm:^1.4.0"
@@ -2206,7 +2206,7 @@ __metadata:
     eslint-plugin-n: "npm:^17.23.2"
     markdownlint-cli2: "npm:~0.19.0"
     rxjs: "npm:^7.8.2"
-    ts-api-utils: "npm:^2.0.0"
+    ts-api-utils: "npm:^2.1.0"
     tslib: "npm:^2.1.0"
     tsup: "npm:8.5.0"
     typescript: "npm:~5.9.3"
@@ -4566,7 +4566,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-api-utils@npm:^2.0.0, ts-api-utils@npm:^2.4.0":
+"ts-api-utils@npm:^2.1.0, ts-api-utils@npm:^2.4.0":
   version: 2.4.0
   resolution: "ts-api-utils@npm:2.4.0"
   peerDependencies:


### PR DESCRIPTION
We're bumping to v0.9, so we can take advantage of the semver jump and raising min versions.

- Minimum version of typescript-eslint is now 8.32.0, to align with their version of ts-api-utils
- Replaced deprecated ts-api-utils unionTypeParts usage
