### PR TITLE
fix(finnish): stop policing object literals by default

### DIFF
--- a/docs/rules/finnish.md
+++ b/docs/rules/finnish.md
@@ -45,6 +45,7 @@ const answer$ = 'green';
 | `functions`  | Require for functions.                                               | Boolean |
 | `methods`    | Require for methods.                                                 | Boolean |
 | `names`      | Enforce for specific names. Keys are a RegExp, values are a boolean. | Object  |
+| `objects`    | Require for object literal keys.                                     | Boolean |
 | `parameters` | Require for parameters.                                              | Boolean |
 | `properties` | Require for properties.                                              | Boolean |
 | `strict`     | Disallow Finnish notation for non-Observables.                       | Boolean |

--- a/src/rules/finnish.ts
+++ b/src/rules/finnish.ts
@@ -12,6 +12,7 @@ const defaultOptions: readonly {
   names?: Record<string, boolean>;
   parameters?: boolean;
   properties?: boolean;
+  objects?: boolean;
   strict?: boolean;
   types?: Record<string, boolean>;
   variables?: boolean;
@@ -36,6 +37,7 @@ export const finnishRule = ruleCreator({
           names: { type: 'object', description: 'Enforce for specific names. Keys are a RegExp, values are a boolean.' },
           parameters: { type: 'boolean', description: 'Require for parameters.' },
           properties: { type: 'boolean', description: 'Require for properties.' },
+          objects: { type: 'boolean', description: 'Require for object literal keys.' },
           strict: { type: 'boolean', description: 'Disallow Finnish notation for non-Observables.' },
           types: { type: 'object', description: 'Enforce for specific types. Keys are a RegExp, values are a boolean.' },
           variables: { type: 'boolean', description: 'Require for variables.' },
@@ -63,6 +65,7 @@ export const finnishRule = ruleCreator({
       parameters: true,
       properties: true,
       variables: true,
+      objects: false,
       ...(config as Record<string, unknown>),
     };
 
@@ -238,7 +241,7 @@ export const finnishRule = ruleCreator({
       'ObjectExpression > Property[computed=false] > Identifier': (
         node: es.Identifier,
       ) => {
-        if (validate.properties) {
+        if (validate.objects) {
           const parent = node.parent as es.Property;
           if (node === parent.key && !isSourcesObjectAcceptingStaticObservableCreator(parent.parent.parent)) {
             checkNode(node);


### PR DESCRIPTION
Fixes #338 

Added an option to ignore object literals ( `objects: boolean` ) and prevent false positives.

Basically, we don't need to lint Object Literals (contracts being fulfilled). We only need to lint Interfaces and Classes (contracts being defined).

Previously, the rule treated object keys identically to class properties, causing errors in 3rd-party configuration objects where property names are fixed contracts that users cannot change. To fix this, I introduced a new objects configuration option that defaults to false, decoupling the validation of object literals from class properties.

The `objects` option is `false` by default, but can be turned on in the configuration as needed. Making it disabled by default aligns the rule with the reality that these structures typically fulfill external contracts rather than define new APIs.

Added test cases that exercise this new option, both at enabled and disabled states.