### PR TITLE
fix(no-unsafe-switchmap): show default disallows, observable opt

### DIFF
--- a/docs/rules/no-unsafe-switchmap.md
+++ b/docs/rules/no-unsafe-switchmap.md
@@ -10,11 +10,11 @@ This rule effects failures if `switchMap` is used in effects or epics that perfo
 
 <!-- begin auto-generated rule options list -->
 
-| Name         | Description                                                                                  | Type   | Default                  |
-| :----------- | :------------------------------------------------------------------------------------------- | :----- | :----------------------- |
-| `allow`      | Action types that are allowed to be used with switchMap. Mutually exclusive with `disallow`. |        |                          |
-| `disallow`   | Action types that are disallowed to be used with switchMap. Mutually exclusive with `allow`. |        |                          |
-| `observable` | A RegExp that matches an effect or epic's actions observable.                                | String | `[Aa]ction(s\|s\$\|\$)$` |
+| Name         | Description                                                                                  | Type   | Default                                                               |
+| :----------- | :------------------------------------------------------------------------------------------- | :----- | :-------------------------------------------------------------------- |
+| `allow`      | Action types that are allowed to be used with switchMap. Mutually exclusive with `disallow`. |        |                                                                       |
+| `disallow`   | Action types that are disallowed to be used with switchMap. Mutually exclusive with `allow`. |        | [`add`, `create`, `delete`, `post`, `put`, `remove`, `set`, `update`] |
+| `observable` | A RegExp that matches an effect or epic's actions observable.                                | String | `[Aa]ction(s\|s\$\|\$)$`                                              |
 
 <!-- end auto-generated rule options list -->
 

--- a/src/rules/no-unsafe-switchmap.ts
+++ b/src/rules/no-unsafe-switchmap.ts
@@ -9,6 +9,17 @@ import {
   isLiteral, isMemberExpression } from '../etc';
 import { createRegExpForWords, ruleCreator } from '../utils';
 
+const DEFAULT_DISALLOW = [
+  'add',
+  'create',
+  'delete',
+  'post',
+  'put',
+  'remove',
+  'set',
+  'update',
+];
+
 const defaultOptions: readonly {
   allow?: string | string[];
   disallow?: string | string[];
@@ -41,6 +52,7 @@ export const noUnsafeSwitchmapRule = ruleCreator({
               { type: 'string', description: 'A regular expression string.' },
               { type: 'array', items: { type: 'string' }, description: 'An array of words.' },
             ],
+            default: DEFAULT_DISALLOW,
           },
           observable: {
             type: 'string',
@@ -62,31 +74,16 @@ export const noUnsafeSwitchmapRule = ruleCreator({
   },
   name: 'no-unsafe-switchmap',
   create: (context) => {
-    const defaultDisallow = [
-      'add',
-      'create',
-      'delete',
-      'post',
-      'put',
-      'remove',
-      'set',
-      'update',
-    ];
-
-    let allowRegExp: RegExp | undefined;
-    let disallowRegExp: RegExp | undefined;
-    let observableRegExp: RegExp;
+    let allowRegExp: RegExp | undefined = undefined;
+    let disallowRegExp: RegExp | undefined = undefined;
 
     const [config = {}] = context.options;
-    if (config.allow || config.disallow) {
+    if (config.allow) {
       allowRegExp = createRegExpForWords(config.allow ?? []);
-      disallowRegExp = createRegExpForWords(config.disallow ?? []);
-      observableRegExp = new RegExp(config.observable ?? defaultObservable);
     } else {
-      allowRegExp = undefined;
-      disallowRegExp = createRegExpForWords(defaultDisallow);
-      observableRegExp = new RegExp(defaultObservable);
+      disallowRegExp = createRegExpForWords(config.disallow ?? DEFAULT_DISALLOW);
     }
+    const observableRegExp = new RegExp(config.observable ?? defaultObservable);
 
     const { couldBeObservable } = getTypeServices(context);
 


### PR DESCRIPTION
Fix two things:

1. When not passing in `allow` nor `disallow` to this rule, it was impossible to change `observable` from its default.
2. The default `disallow` value was not documented in the rule markdown documentation.