### PR TITLE
feat!: require Node.js ^20.19.0 || ^22.13.0 || >=24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18
           - 20
           - 22
           - 24

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@eslint/js": "^10.0.1",
     "@stylistic/eslint-plugin": "^5.8.0",
     "@types/common-tags": "^1.8.4",
-    "@types/node": "~18.18.0",
+    "@types/node": "~20.19.33",
     "@typescript-eslint/rule-tester": "^8.56.0",
     "@typescript/vfs": "^1.6.2",
     "@vitest/coverage-v8": "^3.2.4",
@@ -101,6 +101,6 @@
     "vitest": "^3.2.4"
   },
   "engines": {
-    "node": "^18.18.0 || ^20.9.0 || >= 21.1.0"
+    "node": "^20.19.0 || ^22.13.0 || >=24"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -821,12 +821,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~18.18.0":
-  version: 18.18.14
-  resolution: "@types/node@npm:18.18.14"
+"@types/node@npm:~20.19.33":
+  version: 20.19.33
+  resolution: "@types/node@npm:20.19.33"
   dependencies:
-    undici-types: "npm:~5.26.4"
-  checksum: 10c0/7ab33be7e9ed0501bbbf1e62006b441a1ec5a8969b4f4df796919f3fc851604e2119947b72696e4049dd638a10b27e6f6b4cfaa469787d548d4d9c09fb945968
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/a1a6234a2b6fa577fbb1ccc471e5e54a79c6e1a51be10a67b034461b752a50017854810e943494f20b3c3c6d14df84c93757e0a2ec57aa81c830d6faeab72cf2
   languageName: node
   linkType: hard
 
@@ -2184,7 +2184,7 @@ __metadata:
     "@eslint/js": "npm:^10.0.1"
     "@stylistic/eslint-plugin": "npm:^5.8.0"
     "@types/common-tags": "npm:^1.8.4"
-    "@types/node": "npm:~18.18.0"
+    "@types/node": "npm:~20.19.33"
     "@typescript-eslint/rule-tester": "npm:^8.56.0"
     "@typescript-eslint/scope-manager": "npm:^8.56.0"
     "@typescript-eslint/utils": "npm:^8.56.0"
@@ -4697,10 +4697,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~5.26.4":
-  version: 5.26.5
-  resolution: "undici-types@npm:5.26.5"
-  checksum: 10c0/bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
BREAKING CHANGE: Node.js 18 is no longer supported.

This aligns with ESLint v10's supported versions of Node.js.