### PR TITLE
chore: increase repo package security

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,11 +1,10 @@
-approvedGitRepositories:
-  - "**"
-
 dedupePluginMode: dependabot-only
 
-enableScripts: true
+enableScripts: false
 
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 1
 
 plugins:
   - checksum: c43fb18b0cc042871a14ddc76ec78d35b4bc6896ec1d2b75d137cfc6b6b3e2a83fe6cb8b1d2657700b460e81d843b8dc33c5330db1cce2cffe2d91ce0442eb14

--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
     "vite": "^8.0.12",
     "vitest": "^4.1.6"
   },
+  "dependenciesMeta": {
+    "unrs-resolver": {
+      "built": false
+    }
+  },
   "peerDependencies": {
     "eslint": "^10.0.1",
     "rxjs": "^7.2.0",
@@ -93,7 +98,7 @@
       "optional": true
     }
   },
-  "packageManager": "yarn@4.14.1+sha512.64df448055b2d37ba269d7db535a469b8da93f8ef1140c25fd7a83c00a8fbaacb214ca0e02553b92a2c54cef78bb67d0b4817fab02001df0e24fac0faccc3b42",
+  "packageManager": "yarn@4.15.0+sha512.07ec708ac11e2eaa4ea2b04cfbb272812f7e74a753f1595eaef4486c663a98306a30cca3e6fc40f7a0b168dcfb3a2490b6a5e0501e20fb69cc36f563dd161c53",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10c0
 
 "@altano/repository-tools@npm:^2.0.1":
@@ -2085,6 +2085,9 @@ __metadata:
     eslint: ^10.0.1
     rxjs: ^7.2.0
     typescript: ">=4.8.4 <6.1.0"
+  dependenciesMeta:
+    unrs-resolver:
+      built: false
   peerDependenciesMeta:
     rxjs:
       optional: true


### PR DESCRIPTION
- Disable package scripts
    - unrs-resolver is the only one in this repo, and its build script is optional
- Block git repo dependencies
- Enforce a minimum npm age gate