### PR TITLE
chore: increase repo package security (backport #443)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,10 @@
 dedupePluginMode: dependabot-only
 
+enableScripts: false
+
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 1
 
 plugins:
   - checksum: c43fb18b0cc042871a14ddc76ec78d35b4bc6896ec1d2b75d137cfc6b6b3e2a83fe6cb8b1d2657700b460e81d843b8dc33c5330db1cce2cffe2d91ce0442eb14

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-rxjs-x",
   "type": "commonjs",
   "version": "0.9.5",
-  "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8",
+  "packageManager": "yarn@4.15.0+sha512.07ec708ac11e2eaa4ea2b04cfbb272812f7e74a753f1595eaef4486c663a98306a30cca3e6fc40f7a0b168dcfb3a2490b6a5e0501e20fb69cc36f563dd161c53",
   "description": "Modern ESLint plugin for RxJS",
   "author": "Jason Weinzierl <weinzierljason@gmail.com>",
   "license": "MIT",
@@ -64,6 +64,14 @@
     "decamelize": "^5.0.1",
     "ts-api-utils": "^2.1.0",
     "tslib": "^2.1.0"
+  },
+  "dependenciesMeta": {
+    "esbuild": {
+      "built": true
+    },
+    "unrs-resolver": {
+      "built": false
+    }
   },
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@ampproject/remapping@npm:^2.3.0":
@@ -2229,6 +2229,11 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0
     rxjs: ^7.2.0
     typescript: ">=4.8.4 <6.0.0"
+  dependenciesMeta:
+    esbuild:
+      built: true
+    unrs-resolver:
+      built: false
   peerDependenciesMeta:
     rxjs:
       optional: true


### PR DESCRIPTION
Backport of #443

- Disable package scripts
  - unrs-resolver doesn't need it
  - esbuild does.
- Block git repo dependencies
- Enforce a minimum npm age gate