### PR TITLE
fix(no-sharereplay-before-takeuntil): require strings in option

### DIFF
--- a/docs/rules/no-sharereplay-before-takeuntil.md
+++ b/docs/rules/no-sharereplay-before-takeuntil.md
@@ -31,9 +31,9 @@ source.pipe(
 
 <!-- begin auto-generated rule options list -->
 
-| Name             | Description                              | Type  | Default                |
-| :--------------- | :--------------------------------------- | :---- | :--------------------- |
-| `takeUntilAlias` | List of operators to treat as takeUntil. | Array | [`takeUntilDestroyed`] |
+| Name             | Description                              | Type     | Default                |
+| :--------------- | :--------------------------------------- | :------- | :--------------------- |
+| `takeUntilAlias` | List of operators to treat as takeUntil. | String[] | [`takeUntilDestroyed`] |
 
 <!-- end auto-generated rule options list -->
 

--- a/src/rules/no-sharereplay-before-takeuntil.ts
+++ b/src/rules/no-sharereplay-before-takeuntil.ts
@@ -18,7 +18,11 @@ export const noSharereplayBeforeTakeuntilRule = ruleCreator({
     },
     schema: [{
       properties: {
-        takeUntilAlias: { type: 'array', description: 'List of operators to treat as takeUntil.' },
+        takeUntilAlias: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'List of operators to treat as takeUntil.',
+        },
       },
       type: 'object',
     }],


### PR DESCRIPTION
Restrict `takeUntilAlias` items to just strings, like similar rule options in this plugin.