### PR TITLE
fix(no-exposed-subjects): check implicit returns (backport #381)

### DIFF
--- a/src/etc/get-type-services.ts
+++ b/src/etc/get-type-services.ts
@@ -62,6 +62,8 @@ export function getTypeServices<
     couldBeType,
     couldReturnObservable: (node: es.Node) =>
       couldReturnType(node, 'Observable'),
+    couldReturnSubject: (node: es.Node) =>
+      couldReturnType(node, 'Subject'),
     couldReturnType,
   };
 }

--- a/src/rules/no-exposed-subjects.ts
+++ b/src/rules/no-exposed-subjects.ts
@@ -34,7 +34,7 @@ export const noExposedSubjectsRule = ruleCreator({
   create: (context) => {
     const [config = {}] = context.options;
     const { allowProtected = false } = config;
-    const { couldBeSubject, couldBeType } = getTypeServices(context);
+    const { couldBeSubject, couldReturnSubject, couldBeType, couldReturnType } = getTypeServices(context);
 
     const messageId = allowProtected ? 'forbiddenAllowProtected' : 'forbidden';
     const accessibilityRexExp = allowProtected
@@ -44,6 +44,11 @@ export const noExposedSubjectsRule = ruleCreator({
     function isSubject(node: es.Node) {
       return (
         couldBeSubject(node) && !couldBeType(node, defaultAllowedTypesRegExp)
+      );
+    }
+    function isReturningSubject(node: es.Node) {
+      return (
+        couldReturnSubject(node) && !couldReturnType(node, defaultAllowedTypesRegExp)
       );
     }
 
@@ -99,17 +104,9 @@ export const noExposedSubjectsRule = ruleCreator({
       [`MethodDefinition[accessibility!=${accessibilityRexExp}][kind='method']`]:
         (node: es.MethodDefinition) => {
           const functionExpression = node.value;
-          const returnType = functionExpression.returnType;
-          if (!returnType) {
-            return;
-          }
+          const typeAnnotation = functionExpression.returnType?.typeAnnotation;
 
-          const typeAnnotation = returnType.typeAnnotation;
-          if (!typeAnnotation) {
-            return;
-          }
-
-          if (isSubject(typeAnnotation)) {
+          if ((typeAnnotation && isSubject(typeAnnotation)) || isReturningSubject(functionExpression)) {
             const key = node.key as es.Identifier;
             context.report({
               messageId,

--- a/tests/rules/no-exposed-subjects.test.ts
+++ b/tests/rules/no-exposed-subjects.test.ts
@@ -80,6 +80,16 @@ ruleTester({ types: true }).run('no-exposed-subjects', noExposedSubjectsRule, {
       `,
       options: [{ allowProtected: true }],
     },
+    {
+      name: 'unrelated return',
+      code: stripIndent`
+        class Mock {
+          public a(): number {
+            return 1;
+          }
+        }
+      `,
+    },
   ],
   invalid: [
     fromFixture(
@@ -151,6 +161,42 @@ ruleTester({ types: true }).run('no-exposed-subjects', noExposedSubjectsRule, {
           }
         }
       `,
+    ),
+    fromFixture(
+      'public implicit return type',
+      stripIndent`
+        import { Subject } from 'rxjs';
+
+        class Foo {
+          public a() {
+                 ~ [forbidden { "subject": "a" }]
+            return new Subject<number>();
+          }
+
+          b() {
+          ~ [forbidden { "subject": "b" }]
+            return new Subject<number>();
+          }
+        }
+      `,
+    ),
+    fromFixture(
+      'public implicit return type but allow protected',
+      stripIndent`
+        import { Subject } from 'rxjs';
+
+        class Foo {
+          public a() {
+                 ~ [forbiddenAllowProtected { "subject": "a" }]
+            return new Subject<number>();
+          }
+
+          protected b() {
+            return new Subject<number>();
+          }
+        }
+      `,
+      { options: [{ allowProtected: true }] },
     ),
     fromFixture(
       'public but allow protected',


### PR DESCRIPTION
Backport of #381 to 0.9.x