### PR TITLE
fix(no-unnecessary-collection): spread array literals (backport #485)

### DIFF
--- a/src/rules/no-unnecessary-collection.ts
+++ b/src/rules/no-unnecessary-collection.ts
@@ -39,7 +39,11 @@ export const noUnnecessaryCollectionRule = ruleCreator({
       // Single-valued array.
       if (isArrayExpression(firstArg)) {
         const nonNullElements = firstArg.elements.filter(element => element !== null);
-        if (nonNullElements.length === 1 && couldBeObservable(nonNullElements[0])) {
+        if (
+          nonNullElements.length === 1
+          && !isSpreadElement(nonNullElements[0])
+          && couldBeObservable(nonNullElements[0])
+        ) {
           context.report({
             messageId: 'forbidden',
             node: node.callee,

--- a/tests/rules/no-unnecessary-collection.test.ts
+++ b/tests/rules/no-unnecessary-collection.test.ts
@@ -199,6 +199,16 @@ ruleTester({ types: true }).run('no-unnecessary-collection', noUnnecessaryCollec
         const combined$ = forkJoin(sources);
       `,
     },
+    {
+      name: 'combineLatest with spread array literal',
+      code: stripIndent`
+        import { combineLatest, Observable } from "rxjs";
+
+        function combineObservables(observables: Observable<unknown>[]) {
+          return combineLatest([...observables]);
+        }
+      `,
+    },
     // #endregion
 
     // #region valid; namespace imports


### PR DESCRIPTION
Backport of #485 to 0.9.x