### PR TITLE
fix(no-sharereplay-before-takeuntil): require strings in option (backport #487)

### DIFF
--- a/docs/rules/no-sharereplay-before-takeuntil.md
+++ b/docs/rules/no-sharereplay-before-takeuntil.md
@@ -31,9 +31,9 @@ source.pipe(
 
 <!-- begin auto-generated rule options list -->
 
-| Name             | Description                              | Type  | Default                |
-| :--------------- | :--------------------------------------- | :---- | :--------------------- |
-| `takeUntilAlias` | List of operators to treat as takeUntil. | Array | [`takeUntilDestroyed`] |
+| Name             | Description                              | Type     | Default                |
+| :--------------- | :--------------------------------------- | :------- | :--------------------- |
+| `takeUntilAlias` | List of operators to treat as takeUntil. | String[] | [`takeUntilDestroyed`] |
 
 <!-- end auto-generated rule options list -->
 

--- a/src/rules/no-sharereplay-before-takeuntil.ts
+++ b/src/rules/no-sharereplay-before-takeuntil.ts
@@ -19,7 +19,7 @@ export const noSharereplayBeforeTakeuntilRule = ruleCreator({
     },
     schema: [{
       properties: {
-        takeUntilAlias: { type: 'array', description: 'List of operators to treat as takeUntil.', default: ['takeUntilDestroyed'] },
+        takeUntilAlias: { type: 'array', items: { type: 'string' }, description: 'List of operators to treat as takeUntil.', default: ['takeUntilDestroyed'] },
       },
       type: 'object',
     }],


### PR DESCRIPTION
Backport #487 to 0.9.x