### PR TITLE
fix(finnish): skip function-valued variables when functions are disabled

### DIFF
--- a/src/rules/finnish.ts
+++ b/src/rules/finnish.ts
@@ -3,7 +3,9 @@ import {
   findParent,
   getLoc,
   getTypeServices,
+  isArrowFunctionExpression,
   isCallExpression,
+  isFunctionExpression,
   isTSAsExpression,
   isTSSatisfiesExpression,
   isVariableDeclarator,
@@ -342,9 +344,20 @@ export const finnishRule = ruleCreator({
       },
       'VariableDeclarator > Identifier': (node: es.Identifier) => {
         const parent = node.parent as es.VariableDeclarator;
-        if (config.variables && node === parent.id) {
-          checkNode(node);
+        if (!config.variables || node !== parent.id) {
+          return;
         }
+
+        if (
+          !config.functions
+          && parent.init
+          && (isArrowFunctionExpression(parent.init)
+            || isFunctionExpression(parent.init))
+        ) {
+          return;
+        }
+
+        checkNode(node);
       },
     };
   },

--- a/tests/rules/finnish.test.ts
+++ b/tests/rules/finnish.test.ts
@@ -231,6 +231,8 @@ ruleTester({ types: true }).run('finnish', finnishRule, {
         function someFunction(someParam$: Observable<any>): Observable<any> { return someParam$; }
         (function someFunctionExp(someParam$: Observable<any>): Observable<any> { return someParam$; })();
         function someImplicitReturnFunction(someParam$: Observable<any>) { return someParam$; }
+        const someArrowFunction = (someParam$: Observable<any>): Observable<any> => someParam$;
+        const someFunctionExpression = function (someParam$: Observable<any>): Observable<any> { return someParam$; };
       `,
       options: [{ functions: false }],
     },


### PR DESCRIPTION
Honor `functions: false` for variables initialized with arrow functions or function expressions. Add regression tests covering both initializer types.