### PR TITLE
fix(finnish): skip all function-valued names when functions are disabled

### DIFF
--- a/docs/rules/finnish.md
+++ b/docs/rules/finnish.md
@@ -42,7 +42,7 @@ const answer$ = 'green';
 
 | Name         | Description                                                                | Type    | Default           |
 | :----------- | :------------------------------------------------------------------------- | :------ | :---------------- |
-| `functions`  | Require for functions.                                                     | Boolean | `true`            |
+| `functions`  | Require for function-valued names.                                         | Boolean | `true`            |
 | `methods`    | Require for methods.                                                       | Boolean | `true`            |
 | `names`      | Enforce for specific names. Keys are a RegExp, values are a boolean.       | Object  | `[object Object]` |
 | `objects`    | Require for object literal keys.                                           | Boolean | `true`            |
@@ -58,6 +58,9 @@ This rule accepts a single option which is an object with properties that determ
 
 - `names` and `types` properties that determine whether or not Finnish notation is to be enforced for specific names or types.
 - a `strict` property that, if `true`, allows the `$` suffix to be used _only_ with identifiers that have an `Observable` type.
+
+The `functions` option applies to all function-valued names, including variables, parameters, class and interface properties, and object literal keys.
+Class and interface method declarations remain controlled by the `methods` option.
 
 The default (Angular-friendly) configuration looks like this:
 

--- a/src/etc/could-be-function.ts
+++ b/src/etc/could-be-function.ts
@@ -1,9 +1,12 @@
+import * as tsutils from 'ts-api-utils';
 import ts from 'typescript';
 import { couldBeType } from './could-be-type';
 
 export function couldBeFunction(type: ts.Type): boolean {
   return (
     type.getCallSignatures().length > 0
+    || (tsutils.isUnionOrIntersectionType(type)
+      && type.types.some(couldBeFunction))
     || couldBeType(type, 'Function')
     || couldBeType(type, 'ArrowFunction')
     || couldBeType(type, ts.InternalSymbolName.Function)

--- a/src/rules/finnish.ts
+++ b/src/rules/finnish.ts
@@ -98,9 +98,16 @@ export const finnishRule = ruleCreator({
     function checkNode(
       nameNode: es.Node,
       typeNode?: es.Node,
-      shouldMessage: 'shouldBeFinnish' | 'shouldBeFinnishProperty' = 'shouldBeFinnish',
-      honorFunctionsOption = true,
+      options: {
+        shouldMessage?: 'shouldBeFinnish' | 'shouldBeFinnishProperty';
+        honorFunctionsOption?: boolean;
+      } = {},
     ) {
+      const {
+        shouldMessage = 'shouldBeFinnish',
+        honorFunctionsOption = true,
+      } = options;
+
       if (
         honorFunctionsOption
         && !config.functions
@@ -239,7 +246,7 @@ export const finnishRule = ruleCreator({
       ) => {
         if (!config.methods) return;
         if (node.override) return;
-        checkNode(node.key, node, 'shouldBeFinnish', false);
+        checkNode(node.key, node, { honorFunctionsOption: false });
       },
       'MethodDefinition[kind=\'set\'][computed=false]': (
         node: es.MethodDefinition,
@@ -256,7 +263,7 @@ export const finnishRule = ruleCreator({
         }
 
         if (config.methods && node.kind === 'method') {
-          checkNode(node.key, node, 'shouldBeFinnish', false);
+          checkNode(node.key, node, { honorFunctionsOption: false });
         }
 
         if (config.properties && (node.kind === 'get' || node.kind === 'set')) {
@@ -295,7 +302,7 @@ export const finnishRule = ruleCreator({
 
         const parent = node.parent as es.Property;
         if (node === parent.key) {
-          checkNode(node, undefined, 'shouldBeFinnishProperty');
+          checkNode(node, undefined, { shouldMessage: 'shouldBeFinnishProperty' });
         }
       },
       'ObjectPattern > Property > Identifier': (node: es.Identifier) => {
@@ -332,7 +339,7 @@ export const finnishRule = ruleCreator({
       },
       'TSMethodSignature[computed=false]': (node: es.TSMethodSignature) => {
         if (config.methods) {
-          checkNode(node.key, node, 'shouldBeFinnish', false);
+          checkNode(node.key, node, { honorFunctionsOption: false });
         }
         if (config.parameters) {
           for (const param of node.params) {

--- a/src/rules/finnish.ts
+++ b/src/rules/finnish.ts
@@ -3,9 +3,7 @@ import {
   findParent,
   getLoc,
   getTypeServices,
-  isArrowFunctionExpression,
   isCallExpression,
-  isFunctionExpression,
   isTSAsExpression,
   isTSSatisfiesExpression,
   isVariableDeclarator,
@@ -40,7 +38,7 @@ export const finnishRule = ruleCreator({
     schema: [
       {
         properties: {
-          functions: { type: 'boolean', description: 'Require for functions.' },
+          functions: { type: 'boolean', description: 'Require for function-valued names.' },
           methods: { type: 'boolean', description: 'Require for methods.' },
           names: { type: 'object', description: 'Enforce for specific names. Keys are a RegExp, values are a boolean.' },
           parameters: { type: 'boolean', description: 'Require for parameters.' },
@@ -75,6 +73,7 @@ export const finnishRule = ruleCreator({
     const { esTreeNodeToTSNodeMap } = ESLintUtils.getParserServices(context);
     const {
       couldBeObservable,
+      couldBeFunction,
       couldBeType,
       couldReturnObservable,
       couldReturnType,
@@ -100,7 +99,16 @@ export const finnishRule = ruleCreator({
       nameNode: es.Node,
       typeNode?: es.Node,
       shouldMessage: 'shouldBeFinnish' | 'shouldBeFinnishProperty' = 'shouldBeFinnish',
+      honorFunctionsOption = true,
     ) {
+      if (
+        honorFunctionsOption
+        && !config.functions
+        && couldBeFunction(nameNode)
+      ) {
+        return;
+      }
+
       const tsNode = esTreeNodeToTSNodeMap.get(nameNode);
       const text = tsNode.getText();
       const hasFinnish = text.endsWith('$');
@@ -231,7 +239,7 @@ export const finnishRule = ruleCreator({
       ) => {
         if (!config.methods) return;
         if (node.override) return;
-        checkNode(node.key, node);
+        checkNode(node.key, node, 'shouldBeFinnish', false);
       },
       'MethodDefinition[kind=\'set\'][computed=false]': (
         node: es.MethodDefinition,
@@ -248,7 +256,7 @@ export const finnishRule = ruleCreator({
         }
 
         if (config.methods && node.kind === 'method') {
-          checkNode(node.key, node);
+          checkNode(node.key, node, 'shouldBeFinnish', false);
         }
 
         if (config.properties && (node.kind === 'get' || node.kind === 'set')) {
@@ -324,7 +332,7 @@ export const finnishRule = ruleCreator({
       },
       'TSMethodSignature[computed=false]': (node: es.TSMethodSignature) => {
         if (config.methods) {
-          checkNode(node.key, node);
+          checkNode(node.key, node, 'shouldBeFinnish', false);
         }
         if (config.parameters) {
           for (const param of node.params) {
@@ -345,15 +353,6 @@ export const finnishRule = ruleCreator({
       'VariableDeclarator > Identifier': (node: es.Identifier) => {
         const parent = node.parent as es.VariableDeclarator;
         if (!config.variables || node !== parent.id) {
-          return;
-        }
-
-        if (
-          !config.functions
-          && parent.init
-          && (isArrowFunctionExpression(parent.init)
-            || isFunctionExpression(parent.init))
-        ) {
           return;
         }
 

--- a/tests/rules/finnish.test.ts
+++ b/tests/rules/finnish.test.ts
@@ -222,7 +222,7 @@ ruleTester({ types: true }).run('finnish', finnishRule, {
       ],
     },
     {
-      name: 'functions without $, but not enforced',
+      name: 'function-valued names without $, but not enforced',
       code: stripIndent`
         import { Observable, of } from "rxjs";
 
@@ -231,10 +231,56 @@ ruleTester({ types: true }).run('finnish', finnishRule, {
         function someFunction(someParam$: Observable<any>): Observable<any> { return someParam$; }
         (function someFunctionExp(someParam$: Observable<any>): Observable<any> { return someParam$; })();
         function someImplicitReturnFunction(someParam$: Observable<any>) { return someParam$; }
+        type ObservableFactory = () => Observable<any>;
         const someArrowFunction = (someParam$: Observable<any>): Observable<any> => someParam$;
         const someFunctionExpression = function (someParam$: Observable<any>): Observable<any> { return someParam$; };
+        const someFunctionReference = someFunction;
+        const someTypedFunction: ObservableFactory = someFunction;
+
+        function acceptsFunction(someParam: () => Observable<any>): void {}
+        function acceptsOptionalFunction(someParam: ObservableFactory | undefined): void {}
+        const acceptsArrowFunction = (someParam: () => Observable<any>): void => {};
+
+        class SomeClass {
+          someArrowProperty = (): Observable<any> => someObservable$;
+          someFunctionProperty: ObservableFactory = someFunction;
+          get someFunctionGetter(): ObservableFactory { return someFunction; }
+          constructor(public someParameterProperty: () => Observable<any>) {}
+        }
+
+        interface SomeInterface {
+          someFunctionProperty: ObservableFactory;
+        }
+
+        const someObject = {
+          someArrowProperty: (): Observable<any> => someObservable$,
+          someFunctionProperty: someFunction,
+          someFunctionExpressionProperty: function (): Observable<any> { return someObservable$; },
+          someFunction,
+          someObjectMethod(): Observable<any> { return someObservable$; },
+        };
+
+        const { someArrowProperty, someFunctionProperty } = someObject;
+        const [someFunctionElement] = [someFunction];
       `,
       options: [{ functions: false }],
+    },
+    {
+      name: 'function-valued names with $, but not enforced in strict mode',
+      code: stripIndent`
+        import { Observable, of } from "rxjs";
+
+        type ObservableFactory = () => Observable<any>;
+        const someFunction$ = (): Observable<any> => of(0);
+        function acceptsFunction(factory$: ObservableFactory): void {}
+
+        class SomeClass {
+          someFunctionProperty$: ObservableFactory = someFunction$;
+        }
+
+        const someObject = { someFunctionProperty$: someFunction$ };
+      `,
+      options: [{ functions: false, strict: true }],
     },
     {
       name: 'methods without $, but not enforced',
@@ -600,6 +646,38 @@ ruleTester({ types: true }).run('finnish', finnishRule, {
         function someImplicitReturnFunction(someParam$: Observable<any>) { return someParam$; }
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~ [shouldBeFinnish]
       `,
+    ),
+    fromFixture(
+      'disabling functions still enforces other name categories',
+      stripIndent`
+        import { Observable, of } from "rxjs";
+
+        const observable = of(0);
+              ~~~~~~~~~~ [shouldBeFinnish]
+
+        function acceptsObservable(observable: Observable<any>): void {}
+                                   ~~~~~~~~~~ [shouldBeFinnish]
+
+        class SomeClass {
+          observableProperty: Observable<any>;
+          ~~~~~~~~~~~~~~~~~~ [shouldBeFinnish]
+          get observableGetter(): Observable<any> { return of(0); }
+              ~~~~~~~~~~~~~~~~ [shouldBeFinnish]
+          observableMethod(): Observable<any> { return of(0); }
+          ~~~~~~~~~~~~~~~~ [shouldBeFinnish]
+        }
+
+        interface SomeInterface {
+          observableProperty: Observable<any>;
+          ~~~~~~~~~~~~~~~~~~ [shouldBeFinnish]
+          observableMethod(): Observable<any>;
+          ~~~~~~~~~~~~~~~~ [shouldBeFinnish]
+        }
+
+        const someObject = { observableProperty: of(0) };
+                             ~~~~~~~~~~~~~~~~~~ [shouldBeFinnishProperty]
+      `,
+      { options: [{ functions: false }] },
     ),
     fromFixture(
       'methods without $',


### PR DESCRIPTION
Apply the `functions: false` exemption to every callable-valued name, including parameters, class and interface properties, object properties, getters, references, and destructured bindings.

Recognize callable union and intersection types, while keeping class and interface methods independently controlled by the `methods` option.

Update the rule documentation and add regression coverage for the supported placements and strict mode.